### PR TITLE
Feat/implement commit to pool 147

### DIFF
--- a/.changeset/metal-buses-laugh.md
+++ b/.changeset/metal-buses-laugh.md
@@ -1,0 +1,5 @@
+---
+"@defactor/defactor-sdk": minor
+---
+
+Implement createPool, commitToPool and fix getPool for the Counter Party Pool (CPP)

--- a/src/base-contract.ts
+++ b/src/base-contract.ts
@@ -35,8 +35,8 @@ export interface Views {
 }
 
 export interface AdminFunctions {
-  pause(): Promise<void>
-  unpause(): Promise<void>
+  pause(): Promise<ethers.ContractTransaction | ethers.TransactionResponse>
+  unpause(): Promise<ethers.ContractTransaction | ethers.TransactionResponse>
 }
 
 export abstract class BaseContract {

--- a/src/erc20-collateral-pool.ts
+++ b/src/erc20-collateral-pool.ts
@@ -239,11 +239,11 @@ export class ERC20CollateralPool
     )
   }
 
-  pause(): Promise<void> {
+  pause(): Promise<ethers.ContractTransaction | ethers.TransactionResponse> {
     throw new Error('Method not implemented.')
   }
 
-  unpause(): Promise<void> {
+  unpause(): Promise<ethers.ContractTransaction | ethers.TransactionResponse> {
     throw new Error('Method not implemented.')
   }
 

--- a/src/error-messages.ts
+++ b/src/error-messages.ts
@@ -1,8 +1,8 @@
 export const poolCommonErrorMessage = {
   noExistPoolId: (poolId: bigint) =>
     `Pool id ${poolId.toString()} does not exist`,
-  noSupportedPoolStatus: (poolId: bigint, poolStatus: bigint) =>
-    `Pool id ${poolId.toString()} has a not supported status ${poolStatus.toString()}`,
+  noSupportedPoolStatus: (poolStatus: bigint) =>
+    `The status ${poolStatus.toString()} is not supported`,
   wrongAddressFormat: `Address does not follow the ethereum address format`,
   noNegativeAmountOrZero: 'Amount cannot be negative or 0'
 }

--- a/src/error-messages.ts
+++ b/src/error-messages.ts
@@ -39,6 +39,6 @@ export const cppErrorMessage = {
   noNegativeSoftCapOrZero: 'Amount cannot be negative or 0',
   deadlineReached: 'Deadline has been reached',
   poolIsNotCreated: (poolId: bigint, status: string) =>
-    `Pool ${poolId.toString()} status is ${status}, it must be created`,
+    `Pool ${poolId.toString()} status is ${status}, it must be CREATED`,
   amountExceedsHardCap: 'The amount exceeds the harp cap'
 }

--- a/src/error-messages.ts
+++ b/src/error-messages.ts
@@ -1,4 +1,6 @@
 export const poolCommonErrorMessage = {
+  contractIsPaused: 'The contract is paused',
+  addressIsNotAdmin: 'Sender address is not admin',
   noExistPoolId: (poolId: bigint) =>
     `Pool id ${poolId.toString()} does not exist`,
   noSupportedPoolStatus: (poolStatus: bigint) =>

--- a/src/error-messages.ts
+++ b/src/error-messages.ts
@@ -1,6 +1,8 @@
 export const poolCommonErrorMessage = {
   noExistPoolId: (poolId: bigint) =>
     `Pool id ${poolId.toString()} does not exist`,
+  noSupportedPoolStatus: (poolId: bigint, poolStatus: bigint) =>
+    `Pool id ${poolId.toString()} has a not supported status ${poolStatus.toString()}`,
   wrongAddressFormat: `Address does not follow the ethereum address format`,
   noNegativeAmountOrZero: 'Amount cannot be negative or 0'
 }
@@ -34,5 +36,9 @@ export const ecpErrorMessage = {
 export const cppErrorMessage = {
   softCapMustBeLessThanHardCap: 'Soft cap must be less than hard cap',
   deadlineMustBeInFuture: 'Deadline must be in the future',
-  noNegativeSoftCapOrZero: 'Amount cannot be negative or 0'
+  noNegativeSoftCapOrZero: 'Amount cannot be negative or 0',
+  deadlineReached: 'Deadline has been reached',
+  poolIsNotCreated: (status?: string) =>
+    `Pool status is ${status}, it must be created`,
+  amountExceedsHardCap: 'The amount exceeds the harp cap'
 }

--- a/src/error-messages.ts
+++ b/src/error-messages.ts
@@ -38,7 +38,7 @@ export const cppErrorMessage = {
   deadlineMustBeInFuture: 'Deadline must be in the future',
   noNegativeSoftCapOrZero: 'Amount cannot be negative or 0',
   deadlineReached: 'Deadline has been reached',
-  poolIsNotCreated: (status?: string) =>
-    `Pool status is ${status}, it must be created`,
+  poolIsNotCreated: (poolId: bigint, status: string) =>
+    `Pool ${poolId.toString()} status is ${status}, it must be created`,
   amountExceedsHardCap: 'The amount exceeds the harp cap'
 }

--- a/src/pools.ts
+++ b/src/pools.ts
@@ -43,7 +43,9 @@ export class Pools
   }
 
   private _checkIsNotPaused = async () => {
-    if (await this.isPaused()) {
+    const isPaused = await this.isPaused()
+
+    if (isPaused) {
       throw new Error(poolCommonErrorMessage.contractIsPaused)
     }
   }
@@ -70,7 +72,9 @@ export class Pools
   }
 
   private async _getPoolById(poolId: bigint): Promise<Pool | null> {
-    if (poolId < 0 || poolId >= (await this.contract.poolIndex())) return null
+    const poolIndex = await this.contract.poolIndex()
+
+    if (poolId < 0 || poolId >= poolIndex) return null
 
     const pool: ContractPool = await this.contract.getPool(poolId)
 

--- a/src/pools.ts
+++ b/src/pools.ts
@@ -194,7 +194,7 @@ export class Pools
 
     if (pool.poolStatus !== PoolStatusOption.CREATED) {
       throw new Error(
-        cppErrorMessage.poolIsNotCreated(pool.poolStatus.toLowerCase())
+        cppErrorMessage.poolIsNotCreated(poolId, pool.poolStatus.toLowerCase())
       )
     }
 

--- a/src/pools.ts
+++ b/src/pools.ts
@@ -194,7 +194,7 @@ export class Pools
 
     if (pool.poolStatus !== PoolStatusOption.CREATED) {
       throw new Error(
-        cppErrorMessage.poolIsNotCreated(poolId, pool.poolStatus.toLowerCase())
+        cppErrorMessage.poolIsNotCreated(poolId, pool.poolStatus.toUpperCase())
       )
     }
 

--- a/src/pools.ts
+++ b/src/pools.ts
@@ -39,8 +39,9 @@ export class Pools
   }
 
   private async _getPoolById(poolId: bigint): Promise<Pool | null> {
-    const pool: ContractPool = await this.contract.pools(poolId)
+    if (poolId < 0) return null
 
+    const pool: ContractPool = await this.contract.pools(poolId)
     const statuses = Object.keys(PoolStatusOption)
     const status = Number(pool.poolStatus)
 
@@ -60,7 +61,9 @@ export class Pools
       deadline: pool.deadline,
       closedTime: pool.closedTime,
       poolOwner: pool.poolOwner,
-      collateralToken: pool.collateralToken,
+      collateralToken: Array.isArray(pool.collateralToken)
+        ? pool.collateralToken
+        : [],
       poolStatus: statuses[status] as PoolStatus
     }
 

--- a/src/types/pools.ts
+++ b/src/types/pools.ts
@@ -44,6 +44,20 @@ export type Pool = {
   collateralToken: Array<CollateralToken>
 }
 
+export type ContractPool = {
+  softCap: bigint
+  hardCap: bigint
+  totalCommitted: bigint
+  totalRewards: bigint
+  rewardsPaidOut: bigint
+  createdAt: bigint
+  deadline: bigint
+  closedTime: bigint
+  poolStatus: bigint
+  poolOwner: string
+  collateralToken: Array<CollateralToken>
+}
+
 export interface Functions {
   createPool(
     pool: PoolInput
@@ -52,7 +66,10 @@ export interface Functions {
   depositRewards(poolId: bigint, amount: bigint): Promise<void>
   closePool(poolId: bigint): Promise<void>
   archivePool(poolId: bigint): Promise<void>
-  commitToPool(poolId: bigint, amount: bigint): Promise<void>
+  commitToPool(
+    poolId: bigint,
+    amount: bigint
+  ): Promise<ethers.ContractTransaction | ethers.TransactionResponse>
   uncommitFromPool(poolId: bigint): Promise<void>
   claim(poolId: bigint): Promise<void>
 }

--- a/src/types/pools.ts
+++ b/src/types/pools.ts
@@ -41,7 +41,7 @@ export type Pool = {
   closedTime: bigint
   poolStatus: PoolStatus
   poolOwner: string
-  collateralToken: Array<CollateralToken>
+  collateralTokens: Array<CollateralToken>
 }
 
 export type ContractPool = {
@@ -55,7 +55,7 @@ export type ContractPool = {
   closedTime: bigint
   poolStatus: bigint
   poolOwner: string
-  collateralToken: Array<CollateralToken>
+  collateralTokens: Array<CollateralToken>
 }
 
 export interface Functions {

--- a/src/util.ts
+++ b/src/util.ts
@@ -20,6 +20,10 @@ export const sleep = (ms: number): Promise<void> => {
   return new Promise(resolve => setTimeout(resolve, ms))
 }
 
+export const getUnixEpochTime = () => {
+  return BigInt(Math.floor(Date.now() / 1000))
+}
+
 export const normalizePool = (pool: Pool) => {
   const normalizedPool = normalizer<Pool>(pool, poolKeys)
   normalizedPool.collateralDetails = normalizer<CollateralDetails>(

--- a/test/integration/self-provider-pools.ts
+++ b/test/integration/self-provider-pools.ts
@@ -456,7 +456,7 @@ describe('SelfProvider - Pools', () => {
           softCap: pool.softCap,
           hardCap: pool.hardCap,
           deadline: pool.deadline,
-          collateralTokens: pool.collateralToken
+          collateralTokens: pool.collateralTokens
         }
 
         expect(firstPool).toEqual(coldPoolData)

--- a/test/integration/self-provider-pools.ts
+++ b/test/integration/self-provider-pools.ts
@@ -250,10 +250,11 @@ describe('SelfProvider - Pools', () => {
           provider.contract.address
         )
 
-        if (usdcApproved >= POOL_FEE)
+        if (usdcApproved >= POOL_FEE) {
           throw new Error(
             'Precondition Failed: There are already USDC tokens approved'
           )
+        }
 
         expect.assertions(1)
 
@@ -283,10 +284,11 @@ describe('SelfProvider - Pools', () => {
           provider.contract.address
         )
 
-        if (usdcApproved >= POOL_FEE + collateralAmount)
+        if (usdcApproved >= POOL_FEE + collateralAmount) {
           throw new Error(
-            'Precondition Failed: there are already collateral tokens approved'
+            'Precondition Failed: There are already collateral tokens approved'
           )
+        }
 
         expect.assertions(1)
 
@@ -459,8 +461,9 @@ describe('SelfProvider - Pools', () => {
         const poolId = BigInt(0)
         const pool = await provider.contract.getPool(poolId)
 
-        if (pool.poolStatus === PoolStatusOption.CREATED)
+        if (pool.poolStatus === PoolStatusOption.CREATED) {
           throw new Error('Precondition failed: The status is CREATED')
+        }
 
         expect.assertions(1)
         await expect(
@@ -476,7 +479,11 @@ describe('SelfProvider - Pools', () => {
         if (pool.deadline >= getUnixEpochTime()) {
           const seconds = Number(pool.deadline - getUnixEpochTime()) || 1
 
-          await sleep(seconds * 1000)
+          await sleep(Math.min(seconds, 60) * 1000)
+        }
+
+        if (pool.deadline >= getUnixEpochTime()) {
+          throw new Error('Precondition failed: The deadline has not passed')
         }
 
         expect.assertions(1)
@@ -491,10 +498,11 @@ describe('SelfProvider - Pools', () => {
           provider.contract.address
         )
 
-        if (usdcApproved >= amount)
+        if (usdcApproved >= amount) {
           throw new Error(
             'Precondition Failed: There are already USDC tokens approved'
           )
+        }
 
         expect.assertions(1)
 
@@ -520,10 +528,11 @@ describe('SelfProvider - Pools', () => {
         const pool = await provider.contract.getPool(poolId)
         const amount = BigInt(2_000000)
 
-        if (pool.hardCap < pool.totalCommitted + amount)
+        if (pool.hardCap < pool.totalCommitted + amount) {
           throw new Error(
             'Precondition failed: There is already a total committed'
           )
+        }
 
         expect.assertions(1)
 

--- a/test/integration/self-provider-pools.ts
+++ b/test/integration/self-provider-pools.ts
@@ -353,6 +353,34 @@ describe('SelfProvider - Pools', () => {
         expect(true).toBe(true)
       })
     })
+
+    describe('commitToPool()', () => {
+      it('failure - non-existed pool', async () => {
+        await expect(
+          provider.contract.commitToPool(BigInt(MAX_BIGINT), BigInt(1_000000))
+        ).rejects.toThrow(
+          poolCommonErrorMessage.noExistPoolId(BigInt(MAX_BIGINT))
+        )
+      })
+      it('failure - amount no positive', async () => {
+        await expect(
+          provider.contract.commitToPool(BigInt(1), BigInt(-15_000000))
+        ).rejects.toThrow(poolCommonErrorMessage.noNegativeAmountOrZero)
+      })
+      it('failure - deadline has passed', async () => {
+        await expect(
+          provider.contract.commitToPool(BigInt(0), BigInt(1_000000))
+        ).rejects.toThrow(cppErrorMessage.deadlineReached)
+      })
+      it('failure - amount was not approved', async () => {
+        expect.assertions(1)
+        try {
+          await provider.contract.commitToPool(BigInt(1), BigInt(1_000000))
+        } catch (error) {
+          expect(isError(error, 'CALL_EXCEPTION')).toBeTruthy()
+        }
+      })
+    })
   })
 
   describe('Views', () => {

--- a/test/integration/self-provider-pools.ts
+++ b/test/integration/self-provider-pools.ts
@@ -93,7 +93,7 @@ describe('SelfProvider - Pools', () => {
     })
   })
 
-  describe('AdminFunctions', () => {
+  describe('Admin Functions', () => {
     describe('pause()', () => {
       it('failure - the signer is not admin', async () => {
         expect.assertions(1)

--- a/test/integration/self-provider-pools.ts
+++ b/test/integration/self-provider-pools.ts
@@ -27,7 +27,7 @@ import {
   waitUntilConfirmationCompleted
 } from '../test-util'
 
-jest.setTimeout(50000)
+jest.setTimeout(300000)
 
 describe('SelfProvider - Pools', () => {
   let provider: SelfProvider<Pools>
@@ -38,7 +38,7 @@ describe('SelfProvider - Pools', () => {
   const firstPool: PoolInput = {
     softCap: BigInt(1_000000),
     hardCap: BigInt(5_000000),
-    deadline: BigInt(getUnixEpochTimeInFuture(BigInt(30))),
+    deadline: BigInt(getUnixEpochTimeInFuture(BigInt(120))),
     collateralTokens: []
   }
 
@@ -75,24 +75,14 @@ describe('SelfProvider - Pools', () => {
       throw new Error('signer address is not defined')
     }
 
-    await setPause(provider, false)
-
     for (const collateral of COLLATERAL_ERC20_TOKENS) {
       if (!isAddress(collateral.address) || collateral.precision <= 0) {
         throw new Error(`the collateral ${collateral.address} is invalid`)
       }
     }
 
-    const usdcApproved = await usdcTokenContract.allowance(
-      signerAddress,
-      provider.contract.address
-    )
-
-    if (usdcApproved >= POOL_FEE) {
-      throw new Error(
-        `the contract already has an allowance of ${usdcApproved / BigInt(10 ** 6)} USDC`
-      )
-    }
+    await setPause(provider, false)
+    await approveTokenAmount(usdcTokenContract, provider, BigInt(0))
   })
 
   describe('Constant Variables', () => {

--- a/test/integration/self-provider-pools.ts
+++ b/test/integration/self-provider-pools.ts
@@ -370,6 +370,16 @@ describe('SelfProvider - Pools', () => {
           provider.contract.commitToPool(BigInt(1), BigInt(-15_000000))
         ).rejects.toThrow(poolCommonErrorMessage.noNegativeAmountOrZero)
       })
+      it.skip('failure - status is different to CREATED', async () => {
+        const poolId = BigInt(0)
+        const pool = await provider.contract.getPool(poolId)
+
+        if (pool.poolStatus === 'CREATED') return
+
+        await expect(
+          provider.contract.commitToPool(poolId, BigInt(1_000000))
+        ).rejects.toThrow(cppErrorMessage.poolIsNotCreated(poolId, 'ACTIVE'))
+      })
       it('failure - deadline has passed', async () => {
         const poolId = BigInt(0)
         const pool = await provider.contract.getPool(poolId)

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -138,3 +138,21 @@ export const getRandomERC20Collaterals = (
 
   return collaterals
 }
+
+export const setPause = async (
+  provider: SelfProvider<Pools>,
+  value: boolean
+) => {
+  const isPaused = await provider.contract.isPaused()
+
+  if (isPaused === value) return
+
+  const txPause = value
+    ? await provider.contract.pause()
+    : await provider.contract.unpause()
+
+  await waitUntilConfirmationCompleted(
+    provider.contract.jsonRpcProvider,
+    txPause
+  )
+}

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -43,10 +43,12 @@ export const waitUntilConfirmationCompleted = async (
   }
 }
 
+export const getUnixEpochTime = () => BigInt(Math.floor(Date.now() / 1000))
+
 export const getUnixEpochTimeInFuture = (seconds: bigint) => {
   if (seconds <= 0) throw new Error('seconds must be positive')
 
-  return BigInt(Math.floor(Date.now() / 1000)) + seconds
+  return getUnixEpochTime() + seconds
 }
 
 export const approveTokenAmount = async (


### PR DESCRIPTION
## Implement commitToPool function

### What does this PR do?

- Resolve #147
- Improve and fix test cases
  - Throw an error when the test precondition status is invalid
  - Expect assertions to avoid false positive in async function calls
- Fix `getPool` function
  - Use `poolIndex` to validate the `poolId`
  - Return the pool status as its string value
  - Fix bug that always returned collateral tokens as undefined
- Add admin function to `pause` and `unpause` the contract

### Test Cases for `commitToPool`

   - Failure
      - contract is paused
      - non-existed pool
      - amount no positive
      - deadline has passed
      - the amount was not approved
      - the amount exceeds the hardCap
      - the amount plus the total committed exceeds the hardCap
      - status is different to CREATED _(skipped because it requires a function to change the status)_
   - Sucess
       - commit to pool
### Steps to test

1. Configure the test util with the required contract address, pk, etc
2. Run the test
3. Check the test results

### Test results

![imagen](https://github.com/defactor-com/sdk/assets/66583677/54e236e4-a781-4f51-b742-1cb8e23eb0d8)


#### CheckList

- [X] I build the project
- [X] I included and run the test cases
- [X] I include the changeset file