### PR TITLE
Feat/implement close pool 161

### DIFF
--- a/.changeset/two-turkeys-run.md
+++ b/.changeset/two-turkeys-run.md
@@ -1,0 +1,5 @@
+---
+"@defactor/defactor-sdk": patch
+---
+
+Implement closePool function for the Counter Party Pool (CPP)

--- a/src/errors/error-messages.ts
+++ b/src/errors/error-messages.ts
@@ -41,14 +41,16 @@ export const counterPartyPoolErrorMessage = {
   noNegativeMinimumAPR: 'Minimum APR cannot be negative',
   deadlineReached: 'Deadline has been reached',
   deadlineNotReached: 'Deadline not reached',
+  softCapReached: 'Soft cap reached',
   softCapNotReached: 'Soft cap not reached',
   amountExceedsHardCap: 'The amount exceeds the harp cap',
+  mustDepositAtLeastCommittedAmount: 'Must deposit at least committed amount',
   cannotCollectDaysAfterDeadline: (days: bigint) =>
     `Cannot collect ${days} days after deadline`,
   poolStatusMustBe: (
     poolId: bigint,
     poolStatus: string,
-    expectedStatus: string
+    expectedStatus: Array<string>
   ) =>
-    `Pool ${poolId.toString()} status is ${poolStatus}, it must be ${expectedStatus}`
+    `Pool ${poolId.toString()} status is ${poolStatus}, it must be ${expectedStatus.sort().join(', or ')}`
 }

--- a/src/types/pools.ts
+++ b/src/types/pools.ts
@@ -81,7 +81,9 @@ export interface Functions {
     poolId: bigint,
     amount: bigint
   ): Promise<ethers.ContractTransaction | ethers.TransactionResponse>
-  closePool(poolId: bigint): Promise<void>
+  closePool(
+    poolId: bigint
+  ): Promise<ethers.ContractTransaction | ethers.TransactionResponse>
   archivePool(poolId: bigint): Promise<void>
   commitToPool(
     poolId: bigint,

--- a/test/integration/self-provider-pools.ts
+++ b/test/integration/self-provider-pools.ts
@@ -814,7 +814,6 @@ describe('SelfProvider - Pools', () => {
       it('success - status is ACTIVE and pool owner has deposited enough rewards, close pool', async () => {
         const poolIndex: bigint = await provider.contract.contract.poolIndex()
         const poolId = poolIndex - BigInt(1)
-
         const tx = await provider.contract.closePool(poolId)
 
         await waitUntilConfirmationCompleted(
@@ -881,11 +880,14 @@ describe('SelfProvider - Pools', () => {
 
         await approveTokenAmount(usdcTokenContract, notAdminProvider, amount)
 
-        const tx = await notAdminProvider.contract.commitToPool(poolId, amount)
+        const commitToPoolTx = await notAdminProvider.contract.commitToPool(
+          poolId,
+          amount
+        )
 
         await waitUntilConfirmationCompleted(
           notAdminProvider.contract.jsonRpcProvider,
-          tx
+          commitToPoolTx
         )
 
         // STEP 3. WAIT UNTIL DEADLINE
@@ -924,7 +926,6 @@ describe('SelfProvider - Pools', () => {
         // STEP 2. COMMIT TO POOL
         const poolIndex: bigint = await provider.contract.contract.poolIndex()
         const poolId = poolIndex - BigInt(1)
-
         const amount = BigInt(1_000000)
 
         await approveTokenAmount(usdcTokenContract, notAdminProvider, amount)
@@ -983,7 +984,6 @@ describe('SelfProvider - Pools', () => {
         // STEP 2. COMMIT TO POOL
         const poolIndex: bigint = await provider.contract.contract.poolIndex()
         const poolId = poolIndex - BigInt(1)
-
         const amount = BigInt(2_000000)
 
         await approveTokenAmount(usdcTokenContract, notAdminProvider, amount)
@@ -1090,7 +1090,6 @@ describe('SelfProvider - Pools', () => {
         expect.assertions(1)
 
         const pool = await provider.contract.getPool(BigInt(0))
-
         const coldPoolData = {
           softCap: pool.softCap,
           hardCap: pool.hardCap,


### PR DESCRIPTION
## Implement `closePool` function

### What does this PR do?

- Resolve #161 

### Test Cases for `closePool`

   - Failure
      - contract is paused
      - non-existed pool
      - the signer is not the owner of the pool
      - Status is `CREATED`
         - deadline has not passed
         - soft cap reached and the max collect time has not passed `( pool.softCap < pool.totalCommitted && ! ( pool.deadline + 30 days < block.timestamp ) )`
      - Status is `ACTIVE` and the deposited amount is less than the committed amount `pool.totalRewards < pool.totalCommitted + (pool.totalCommitted * pool.minimumAPR) / INTEREST_DECIMAL_PLACES`
      - Status is not `CREATED` or `ACTIVE`
   - Sucess
       - pool status is `CREATED` and the max collect time has passed `pool.deadline + COLLECT_POOL_MAX_TIME < block.timestamp`
       - pool status is `ACTIVE` and the owner of the pool has deposited enough rewards

### Steps to test

1. Configure the test util with the required contract address, pk, etc
2. Run the test
3. Check the test results

### Test results

![imagen](https://github.com/defactor-com/sdk/assets/66583677/346213f7-887f-4bb3-9813-017f821dbd3b)

#### CheckList

- [X] I build the project
- [X] I included and run the test cases
- [X] I include the changeset file