### PR TITLE
feat: add grant and revoke admin role #218 #219

### DIFF
--- a/.changeset/wild-tips-breathe.md
+++ b/.changeset/wild-tips-breathe.md
@@ -1,0 +1,5 @@
+---
+"@defactor/defactor-sdk": patch
+---
+
+Add grantRole and revokeRole functions to base contract class

--- a/src/base-classes/base-contract.ts
+++ b/src/base-classes/base-contract.ts
@@ -2,7 +2,7 @@ import { Contract, ethers } from 'ethers'
 
 import { miscErc20CollateralPool } from '../artifacts'
 import { commonErrorMessage } from '../errors'
-import { Abi, PrivateKey } from '../types/types'
+import { Abi, PrivateKey, RoleOption } from '../types/types'
 import { Role } from '../utilities/util'
 
 export type BaseContractConstructorParams = ConstructorParameters<
@@ -75,6 +75,41 @@ export abstract class BaseContract {
     await this._checkIsAdmin()
 
     const pop = await this.contract.unpause.populateTransaction()
+
+    return this.signer ? await this.signer.sendTransaction(pop) : pop
+  }
+
+  async grantRole(
+    role: RoleOption,
+    address: string
+  ): Promise<ethers.ContractTransaction | ethers.TransactionResponse> {
+    await this._checkIsNotPaused()
+    await this._checkIsAdmin()
+
+    if (!ethers.isAddress(address)) {
+      throw new Error(commonErrorMessage.wrongAddressFormat)
+    }
+
+    const pop = await this.contract.grantRole.populateTransaction(role, address)
+
+    return this.signer ? await this.signer.sendTransaction(pop) : pop
+  }
+
+  async revokeRole(
+    role: RoleOption,
+    address: string
+  ): Promise<ethers.ContractTransaction | ethers.TransactionResponse> {
+    await this._checkIsNotPaused()
+    await this._checkIsAdmin()
+
+    if (!ethers.isAddress(address)) {
+      throw new Error(commonErrorMessage.wrongAddressFormat)
+    }
+
+    const pop = await this.contract.revokeRole.populateTransaction(
+      role,
+      address
+    )
 
     return this.signer ? await this.signer.sendTransaction(pop) : pop
   }

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -3,6 +3,7 @@ import { ethers } from 'ethers'
 import { ERC20CollateralPool } from '../pools/erc20-collateral-pool'
 import { Pools } from '../pools/pools'
 import { Staking } from '../staking/staking'
+import { Role } from '../utilities/util'
 
 export type ERC20CollateralPoolConstructorParams = ConstructorParameters<
   typeof ERC20CollateralPool
@@ -26,3 +27,5 @@ export type Pagination<T> = {
   data: Array<T>
   more: boolean
 }
+
+export type RoleOption = (typeof Role)[keyof typeof Role]


### PR DESCRIPTION
## Add admin functions to grant and revoke contract roles

### What does this PR do?

- Resolve #218
- Resolve #219

### New Tests

- Test `grantRole` 
  - The contract is not paused
  - The signer is not admin
  - The address has a wrong format
  - Grant the default admin role
  - Grant a different role
  
 - Test `revokeRole` 
  - The contract is not paused
  - The signer is not admin
  - The address has a wrong format
  - Revoke the default admin role
  - Revoke the previous role

### Steps to test

1. Run the staking test cases
2. Check the results

### Screenshots

![image](https://github.com/user-attachments/assets/234d1847-304d-4162-b896-8ad9e84300a5)

#### CheckList

- [ ] Follow proper Markdown format
- [ ] Content is available in all languages
- [ ] The content is adequate
- [ ] I Ran a spell check
- [X] I included test coverage
