### PR TITLE
feat: support min and max erc20 collateral pool values

### DIFF
--- a/.changeset/modern-spoons-smell.md
+++ b/.changeset/modern-spoons-smell.md
@@ -6,6 +6,10 @@ Support new version of the ERC20 Collateral Pool contract
 
 ### Breaking changes
 
+  - Add functions `getLiquidatableAmountWithProtocolFee` and `liquidateUserPosition` into `ERC20CollateralPool` class.
+
+  - Now `liquidatePool` function requires `DEFAULT_ADMIN_ROLE`.
+
   - The collateral details in `ERC20CollateralPool` class that implements the erc20 collateral pool contract now require `maxLended`, `minLended`, and `minBorrow`.
 
   - The `LIQUIDATION_FEE` in the `ERC20CollateralPool` base class has changed from 5 to 10.

--- a/.changeset/modern-spoons-smell.md
+++ b/.changeset/modern-spoons-smell.md
@@ -1,0 +1,13 @@
+---
+"@defactor/defactor-sdk": major
+---
+
+Support new version of the ERC20 Collateral Pool contract
+
+### Breaking changes
+
+  - The collateral details in `ERC20CollateralPool` class that implements the erc20 collateral pool contract now require `maxLended`, `minLended`, and `minBorrow`.
+
+  - The `LIQUIDATION_FEE` in the `ERC20CollateralPool` base class has changed from 5 to 10.
+
+  - The `OZ_IN_G` was removed from the `ERC20CollateralPool` base class and the classes from which it inherits.

--- a/src/artifacts/ERC20CollateralPool.json
+++ b/src/artifacts/ERC20CollateralPool.json
@@ -20,7 +20,7 @@
     },
     {
       "inputs": [],
-      "name": "InvalidUSDCAddress",
+      "name": "MaxLendedIsReached",
       "type": "error"
     },
     {
@@ -407,6 +407,37 @@
       "type": "event"
     },
     {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "poolId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "borrowId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "liquidator",
+          "type": "address"
+        }
+      ],
+      "name": "UserPositionLiquidated",
+      "type": "event"
+    },
+    {
       "inputs": [],
       "name": "DEFAULT_ADMIN_ROLE",
       "outputs": [
@@ -473,19 +504,6 @@
     },
     {
       "inputs": [],
-      "name": "OZ_IN_G",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
       "name": "USDC",
       "outputs": [
         {
@@ -511,6 +529,11 @@
         },
         {
           "components": [
+            {
+              "internalType": "uint256",
+              "name": "maxLended",
+              "type": "uint256"
+            },
             {
               "internalType": "uint48",
               "name": "endTime",
@@ -556,6 +579,11 @@
       "inputs": [
         {
           "components": [
+            {
+              "internalType": "uint256",
+              "name": "maxLended",
+              "type": "uint256"
+            },
             {
               "internalType": "uint48",
               "name": "endTime",
@@ -606,6 +634,11 @@
         },
         {
           "components": [
+            {
+              "internalType": "uint256",
+              "name": "maxLended",
+              "type": "uint256"
+            },
             {
               "internalType": "uint48",
               "name": "endTime",
@@ -664,6 +697,11 @@
         },
         {
           "components": [
+            {
+              "internalType": "uint256",
+              "name": "maxLended",
+              "type": "uint256"
+            },
             {
               "internalType": "uint48",
               "name": "endTime",
@@ -918,6 +956,35 @@
       "type": "function"
     },
     {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "poolId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "borrowId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getLiquidatableAmountWithProtocolFee",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [],
       "name": "getPools",
       "outputs": [
@@ -980,6 +1047,11 @@
             },
             {
               "components": [
+                {
+                  "internalType": "uint256",
+                  "name": "maxLended",
+                  "type": "uint256"
+                },
                 {
                   "internalType": "contract ERC20Upgradeable",
                   "name": "collateralToken",
@@ -1180,6 +1252,29 @@
       "type": "function"
     },
     {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "poolId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "borrowId",
+          "type": "uint256"
+        }
+      ],
+      "name": "liquidateUserPosition",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
       "inputs": [],
       "name": "pause",
       "outputs": [],
@@ -1266,6 +1361,11 @@
         },
         {
           "components": [
+            {
+              "internalType": "uint256",
+              "name": "maxLended",
+              "type": "uint256"
+            },
             {
               "internalType": "contract ERC20Upgradeable",
               "name": "collateralToken",

--- a/src/artifacts/ERC20CollateralPool.json
+++ b/src/artifacts/ERC20CollateralPool.json
@@ -15,6 +15,11 @@
     },
     {
       "inputs": [],
+      "name": "AmountTooLow",
+      "type": "error"
+    },
+    {
+      "inputs": [],
       "name": "ChainlinkDataTooOld",
       "type": "error"
     },
@@ -535,6 +540,16 @@
               "type": "uint256"
             },
             {
+              "internalType": "uint256",
+              "name": "minLended",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minBorrow",
+              "type": "uint256"
+            },
+            {
               "internalType": "uint48",
               "name": "endTime",
               "type": "uint48"
@@ -582,6 +597,16 @@
             {
               "internalType": "uint256",
               "name": "maxLended",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minLended",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minBorrow",
               "type": "uint256"
             },
             {
@@ -637,6 +662,16 @@
             {
               "internalType": "uint256",
               "name": "maxLended",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minLended",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minBorrow",
               "type": "uint256"
             },
             {
@@ -700,6 +735,16 @@
             {
               "internalType": "uint256",
               "name": "maxLended",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minLended",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minBorrow",
               "type": "uint256"
             },
             {
@@ -1053,6 +1098,16 @@
                   "type": "uint256"
                 },
                 {
+                  "internalType": "uint256",
+                  "name": "minLended",
+                  "type": "uint256"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "minBorrow",
+                  "type": "uint256"
+                },
+                {
                   "internalType": "contract ERC20Upgradeable",
                   "name": "collateralToken",
                   "type": "address"
@@ -1364,6 +1419,16 @@
             {
               "internalType": "uint256",
               "name": "maxLended",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minLended",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "minBorrow",
               "type": "uint256"
             },
             {

--- a/src/errors/error-messages.ts
+++ b/src/errors/error-messages.ts
@@ -32,7 +32,10 @@ export const erc20CollateralPoolErrorMessage = {
   poolCannotBeLiquidated: 'Pool cannot be liquidated',
   timeMustBeInFuture: 'Time must be in the future',
   amountOverpassPoolBalance: 'Amount overpass the pool available amount',
-  borrowAlreadyRepaid: 'Borrow already repaid'
+  borrowAlreadyRepaid: 'Borrow already repaid',
+  amountTooLow: 'The amount is less than or equal to the minimum',
+  minLendedMustBeLessThanMaxLended:
+    'The min lended amount must be less than max lended amount'
 }
 
 export const counterPartyPoolErrorMessage = {

--- a/src/errors/error-messages.ts
+++ b/src/errors/error-messages.ts
@@ -25,7 +25,6 @@ export const erc20CollateralPoolErrorMessage = {
   maxLentIsReached: 'Max lent is reached',
   endTimeReached: 'Pool has ended',
   poolIsNotClosed: 'Pool is not closed',
-  maxLendedIsReached: 'Max lended is reached',
   poolIsClosed: 'Pool is closed',
   poolIsNotCompleted: 'Pool is not completed',
   loanAlreadyClaimed: 'Loan already claimed',

--- a/src/errors/error-messages.ts
+++ b/src/errors/error-messages.ts
@@ -33,10 +33,10 @@ export const erc20CollateralPoolErrorMessage = {
   amountOverpassPoolBalance: 'Amount overpass the pool available amount',
   borrowAlreadyRepaid: 'Borrow already repaid',
   amountTooLow: 'The amount is less than or equal to the minimum',
-  minLendedMustBeLessThanMaxLended:
-    'The min lended amount must be less than max lended amount',
-  minBorrowMustBeLessThanMaxLended:
-    'The min borrow amount must be less than max lended amount'
+  minLentMustBeLessThanMaxLent:
+    'The min lent amount must be less than max lent amount',
+  minBorrowMustBeLessThanMaxLent:
+    'The min borrow amount must be less than max lent amount'
 }
 
 export const counterPartyPoolErrorMessage = {

--- a/src/errors/error-messages.ts
+++ b/src/errors/error-messages.ts
@@ -34,7 +34,9 @@ export const erc20CollateralPoolErrorMessage = {
   borrowAlreadyRepaid: 'Borrow already repaid',
   amountTooLow: 'The amount is less than or equal to the minimum',
   minLendedMustBeLessThanMaxLended:
-    'The min lended amount must be less than max lended amount'
+    'The min lended amount must be less than max lended amount',
+  minBorrowMustBeLessThanMaxLended:
+    'The min borrow amount must be less than max lended amount'
 }
 
 export const counterPartyPoolErrorMessage = {

--- a/src/pools/erc20-collateral-pool-toplend.ts
+++ b/src/pools/erc20-collateral-pool-toplend.ts
@@ -256,6 +256,18 @@ export class ERC20CollateralPoolToplend extends ERC20CollateralPool {
       throw new Error(ecpErrorMessage.timeMustBeInFuture)
     }
 
+    if (
+      pool.collateralDetails.maxLended <= 0 ||
+      pool.collateralDetails.minLended <= 0 ||
+      pool.collateralDetails.minBorrow <= 0
+    ) {
+      throw new Error(poolCommonErrorMessage.noNegativeAmountOrZero)
+    }
+
+    if (pool.collateralDetails.minLended > pool.collateralDetails.maxLended) {
+      throw new Error(ecpErrorMessage.minLendedMustBeLessThanMaxLended)
+    }
+
     if (this.signer) {
       const isAdmin = await this.contract.hasRole(Role.ADMIN, this.signer)
 
@@ -266,6 +278,8 @@ export class ERC20CollateralPoolToplend extends ERC20CollateralPool {
 
     const formattedPool = {
       maxLended: pool.collateralDetails.maxLended,
+      minLended: pool.collateralDetails.minLended,
+      minBorrow: pool.collateralDetails.minBorrow,
       endTime: pool.endTime,
       interest: pool.interest,
       collateralToken: pool.collateralDetails.collateralToken,
@@ -294,6 +308,10 @@ export class ERC20CollateralPoolToplend extends ERC20CollateralPool {
       throw new Error(poolCommonErrorMessage.noNegativeAmountOrZero)
     }
 
+    if (amount < pool.collateralDetails.minLended) {
+      throw new Error(ecpErrorMessage.amountTooLow)
+    }
+
     if (
       pool.lended - pool.repaid + amount >
       BigInt(pool.collateralDetails.maxLended)
@@ -314,6 +332,10 @@ export class ERC20CollateralPoolToplend extends ERC20CollateralPool {
 
     if (amount <= 0) {
       throw new Error(poolCommonErrorMessage.noNegativeAmountOrZero)
+    }
+
+    if (amount < pool.collateralDetails.minBorrow) {
+      throw new Error(ecpErrorMessage.amountTooLow)
     }
 
     if (pool.endTime <= Date.now() / 1000) {

--- a/src/pools/erc20-collateral-pool-toplend.ts
+++ b/src/pools/erc20-collateral-pool-toplend.ts
@@ -501,7 +501,7 @@ export class ERC20CollateralPoolToplend extends ERC20CollateralPool {
   }
 
   async getLiquidationInfo(pool: Pool): Promise<PoolLiquidationInfo> {
-    if (pool.endTime > Date.now()) {
+    if (pool.endTime > Date.now() / 1000) {
       throw new Error(ecpErrorMessage.poolIsNotClosed)
     }
 
@@ -542,7 +542,7 @@ export class ERC20CollateralPoolToplend extends ERC20CollateralPool {
 
     const pool = await this.getPool(poolId)
 
-    if (pool.endTime > Date.now()) {
+    if (pool.endTime > Date.now() / 1000) {
       throw new Error(ecpErrorMessage.poolIsNotClosed)
     }
 

--- a/src/pools/erc20-collateral-pool-toplend.ts
+++ b/src/pools/erc20-collateral-pool-toplend.ts
@@ -19,6 +19,8 @@ import { Abi, Pagination, PrivateKey } from '../types/types'
 import { NULL_ADDRESS, Role } from '../utilities/util'
 
 export class ERC20CollateralPoolToplend extends ERC20CollateralPool {
+  readonly LIQUIDATION_FEE = BigInt(5)
+
   constructor(
     address: string,
     apiUrl: string,
@@ -256,16 +258,8 @@ export class ERC20CollateralPoolToplend extends ERC20CollateralPool {
       throw new Error(ecpErrorMessage.timeMustBeInFuture)
     }
 
-    if (
-      pool.collateralDetails.maxLended <= 0 ||
-      pool.collateralDetails.minLended <= 0 ||
-      pool.collateralDetails.minBorrow <= 0
-    ) {
+    if (pool.collateralDetails.maxLended <= 0) {
       throw new Error(poolCommonErrorMessage.noNegativeAmountOrZero)
-    }
-
-    if (pool.collateralDetails.minLended > pool.collateralDetails.maxLended) {
-      throw new Error(ecpErrorMessage.minLendedMustBeLessThanMaxLended)
     }
 
     if (this.signer) {
@@ -278,8 +272,6 @@ export class ERC20CollateralPoolToplend extends ERC20CollateralPool {
 
     const formattedPool = {
       maxLended: pool.collateralDetails.maxLended,
-      minLended: pool.collateralDetails.minLended,
-      minBorrow: pool.collateralDetails.minBorrow,
       endTime: pool.endTime,
       interest: pool.interest,
       collateralToken: pool.collateralDetails.collateralToken,

--- a/src/pools/erc20-collateral-pool-toplend.ts
+++ b/src/pools/erc20-collateral-pool-toplend.ts
@@ -235,14 +235,6 @@ export class ERC20CollateralPoolToplend extends ERC20CollateralPool {
     )
   }
 
-  pause(): Promise<ethers.ContractTransaction | ethers.TransactionResponse> {
-    throw new Error('Method not implemented.')
-  }
-
-  unpause(): Promise<ethers.ContractTransaction | ethers.TransactionResponse> {
-    throw new Error('Method not implemented.')
-  }
-
   async addPool(
     pool: PoolInput
   ): Promise<ethers.ContractTransaction | ethers.TransactionResponse> {
@@ -290,6 +282,8 @@ export class ERC20CollateralPoolToplend extends ERC20CollateralPool {
     poolId: bigint,
     amount: bigint
   ): Promise<ethers.ContractTransaction | ethers.TransactionResponse> {
+    await this._checkIsNotPaused()
+
     const pool = await this.getPool(poolId)
 
     if (pool.endTime <= Date.now() / 1000) {
@@ -320,6 +314,8 @@ export class ERC20CollateralPoolToplend extends ERC20CollateralPool {
     poolId: bigint,
     amount: bigint
   ): Promise<ethers.ContractTransaction | ethers.TransactionResponse> {
+    await this._checkIsNotPaused()
+
     const pool = await this.getPool(poolId)
 
     if (amount <= 0) {
@@ -445,6 +441,7 @@ export class ERC20CollateralPoolToplend extends ERC20CollateralPool {
     borrowerAddress: string,
     borrowId: bigint
   ): Promise<ethers.ContractTransaction | ethers.TransactionResponse> {
+    await this._checkIsNotPaused()
     await this.getPool(poolId)
 
     if (!ethers.isAddress(borrowerAddress)) {
@@ -467,6 +464,8 @@ export class ERC20CollateralPoolToplend extends ERC20CollateralPool {
     address: string,
     lendingId: bigint
   ): Promise<ethers.ContractTransaction | ethers.TransactionResponse> {
+    await this._checkIsNotPaused()
+
     const pool = await this.getPool(poolId)
 
     if (pool.endTime > Date.now() / 1000) {
@@ -538,6 +537,9 @@ export class ERC20CollateralPoolToplend extends ERC20CollateralPool {
   async liquidatePool(
     poolId: bigint
   ): Promise<ethers.ContractTransaction | ethers.TransactionResponse> {
+    await this._checkIsNotPaused()
+    await this._checkIsAdmin()
+
     const pool = await this.getPool(poolId)
 
     if (pool.endTime > Date.now()) {

--- a/src/pools/erc20-collateral-pool.ts
+++ b/src/pools/erc20-collateral-pool.ts
@@ -239,14 +239,6 @@ export class ERC20CollateralPool
     )
   }
 
-  pause(): Promise<ethers.ContractTransaction | ethers.TransactionResponse> {
-    throw new Error('Method not implemented.')
-  }
-
-  unpause(): Promise<ethers.ContractTransaction | ethers.TransactionResponse> {
-    throw new Error('Method not implemented.')
-  }
-
   async addPool(
     pool: PoolInput
   ): Promise<ethers.ContractTransaction | ethers.TransactionResponse> {

--- a/src/pools/erc20-collateral-pool.ts
+++ b/src/pools/erc20-collateral-pool.ts
@@ -263,9 +263,9 @@ export class ERC20CollateralPool
     }
 
     if (
-      pool.collateralDetails.maxLended <= 0 ||
-      pool.collateralDetails.minLended <= 0 ||
-      pool.collateralDetails.minBorrow <= 0
+      BigInt(pool.collateralDetails.maxLended || 0) <= 0 ||
+      BigInt(pool.collateralDetails.minLended || 0) <= 0 ||
+      BigInt(pool.collateralDetails.minBorrow || 0) <= 0
     ) {
       throw new Error(poolCommonErrorMessage.noNegativeAmountOrZero)
     }

--- a/src/pools/erc20-collateral-pool.ts
+++ b/src/pools/erc20-collateral-pool.ts
@@ -283,11 +283,11 @@ export class ERC20CollateralPool
     }
 
     const formattedPool = {
-      endTime: pool.endTime,
-      interest: pool.interest,
       maxLended: pool.collateralDetails.maxLended,
       minLended: pool.collateralDetails.minLended,
       minBorrow: pool.collateralDetails.minBorrow,
+      endTime: pool.endTime,
+      interest: pool.interest,
       collateralToken: pool.collateralDetails.collateralToken,
       collateralTokenChainlink: pool.collateralDetails.collateralTokenChainlink,
       collateralTokenFactor: pool.collateralDetails.collateralTokenFactor,

--- a/src/pools/erc20-collateral-pool.ts
+++ b/src/pools/erc20-collateral-pool.ts
@@ -263,11 +263,11 @@ export class ERC20CollateralPool
     }
 
     if (pool.collateralDetails.minLended > pool.collateralDetails.maxLended) {
-      throw new Error(ecpErrorMessage.minLendedMustBeLessThanMaxLended)
+      throw new Error(ecpErrorMessage.minLentMustBeLessThanMaxLent)
     }
 
     if (pool.collateralDetails.minBorrow > pool.collateralDetails.maxLended) {
-      throw new Error(ecpErrorMessage.minBorrowMustBeLessThanMaxLended)
+      throw new Error(ecpErrorMessage.minBorrowMustBeLessThanMaxLent)
     }
 
     if (this.signer) {

--- a/src/pools/erc20-collateral-pool.ts
+++ b/src/pools/erc20-collateral-pool.ts
@@ -319,7 +319,7 @@ export class ERC20CollateralPool
     }
 
     if (pool.lended - pool.repaid + amount > pool.collateralDetails.maxLended) {
-      throw new Error(ecpErrorMessage.maxLendedIsReached)
+      throw new Error(ecpErrorMessage.maxLentIsReached)
     }
 
     const pop = await this.contract.lend.populateTransaction(poolId, amount)

--- a/src/pools/erc20-collateral-pool.ts
+++ b/src/pools/erc20-collateral-pool.ts
@@ -274,6 +274,10 @@ export class ERC20CollateralPool
       throw new Error(ecpErrorMessage.minLendedMustBeLessThanMaxLended)
     }
 
+    if (pool.collateralDetails.minBorrow > pool.collateralDetails.maxLended) {
+      throw new Error(ecpErrorMessage.minBorrowMustBeLessThanMaxLended)
+    }
+
     if (this.signer) {
       const isAdmin = await this.contract.hasRole(Role.ADMIN, this.signer)
 

--- a/src/types/erc20-collateral-pool-toplend.ts
+++ b/src/types/erc20-collateral-pool-toplend.ts
@@ -33,7 +33,7 @@ export type CollateralDetails = {
 export type PoolInput = {
   endTime: number
   interest: number
-  collateralDetails: CollateralDetails
+  collateralDetails: Omit<CollateralDetails, 'minLended' | 'minBorrow'>
 }
 
 // TODO: use uint48 instead of number for lastUpdated and endTime

--- a/src/types/erc20-collateral-pool-toplend.ts
+++ b/src/types/erc20-collateral-pool-toplend.ts
@@ -21,6 +21,8 @@ export type Lend = {
 // TODO: use uint8 instead of number for collateralTokenFactor and collateralTokenPercentage
 export type CollateralDetails = {
   maxLended: number
+  minLended: number
+  minBorrow: number
   collateralToken: string
   collateralTokenChainlink: string
   collateralTokenFactor: number

--- a/src/types/erc20-collateral-token.ts
+++ b/src/types/erc20-collateral-token.ts
@@ -20,6 +20,9 @@ export type Lend = {
 
 // TODO: use uint8 instead of number for collateralTokenFactor and collateralTokenPercentage
 export type CollateralDetails = {
+  maxLended: number
+  minLended: number
+  minBorrow: number
   collateralToken: string
   collateralTokenChainlink: string
   collateralTokenFactor: number

--- a/src/types/erc20-collateral-token.ts
+++ b/src/types/erc20-collateral-token.ts
@@ -147,6 +147,9 @@ export const poolKeys: Array<keyof Pool> = [
 ]
 
 export const collateralDetailsKeys: Array<keyof CollateralDetails> = [
+  'maxLended',
+  'minLended',
+  'minBorrow',
   'collateralToken',
   'collateralTokenChainlink',
   'collateralTokenFactor',

--- a/test/integration/self-provider-erc20collateralpool.ts
+++ b/test/integration/self-provider-erc20collateralpool.ts
@@ -1111,7 +1111,7 @@ describe('SelfProvider - ERC20CollateralPool', () => {
               collateralTokenPercentage: 15
             }
           })
-        ).rejects.toThrow(ecpErrorMessage.minLendedMustBeLessThanMaxLended)
+        ).rejects.toThrow(ecpErrorMessage.minLentMustBeLessThanMaxLent)
       })
 
       it('failure - create pool with a min lended of zero', async () => {
@@ -1165,7 +1165,7 @@ describe('SelfProvider - ERC20CollateralPool', () => {
               collateralTokenPercentage: 15
             }
           })
-        ).rejects.toThrow(ecpErrorMessage.minBorrowMustBeLessThanMaxLended)
+        ).rejects.toThrow(ecpErrorMessage.minBorrowMustBeLessThanMaxLent)
       })
 
       it('success - create pool', async () => {

--- a/test/integration/self-provider-erc20collateralpool.ts
+++ b/test/integration/self-provider-erc20collateralpool.ts
@@ -831,6 +831,46 @@ describe('SelfProvider - ERC20CollateralPool', () => {
         expect(liquidationInfo).toEqual(expectedLiquidationInfo)
       })
     })
+    describe('getLiquidatableAmountWithProtocolFee()', () => {
+      it('failure - pool id does not exist', async () => {
+        await expect(
+          provider.contract.getLiquidatableAmountWithProtocolFee(
+            MAX_BIGINT,
+            TESTING_PUBLIC_KEY,
+            BigInt(0)
+          )
+        ).rejects.toThrow(poolCommonErrorMessage.noExistPoolId(MAX_BIGINT))
+      })
+      it('failure - wrong address format', async () => {
+        await expect(
+          provider.contract.getLiquidatableAmountWithProtocolFee(
+            BigInt(0),
+            '0xinvalid',
+            BigInt(0)
+          )
+        ).rejects.toThrow(commonErrorMessage.wrongAddressFormat)
+      })
+      it('failure - borrow id does not exist', async () => {
+        await expect(
+          provider.contract.getLiquidatableAmountWithProtocolFee(
+            BigInt(0),
+            TESTING_PUBLIC_KEY,
+            MAX_BIGINT
+          )
+        ).rejects.toThrow(ecpErrorMessage.noExistBorrowId(MAX_BIGINT))
+      })
+      it('success - get liquidatable amount with protocol fee', async () => {
+        const amount =
+          await provider.contract.getLiquidatableAmountWithProtocolFee(
+            BigInt(6),
+            TESTING_PUBLIC_KEY,
+            BigInt(0)
+          )
+
+        expect(typeof amount).toBe('bigint')
+        expect(amount).toBeGreaterThanOrEqual(BigInt(0))
+      })
+    })
   })
 
   describe('Functions', () => {
@@ -1423,6 +1463,54 @@ describe('SelfProvider - ERC20CollateralPool', () => {
         const loanId = BigInt(0)
 
         await provider.contract.claimRewards(poolId, TESTING_PUBLIC_KEY, loanId)
+      })
+    })
+
+    describe('liquidateUserPosition', () => {
+      it('failure - wrong address format', async () => {
+        await expect(
+          provider.contract.liquidateUserPosition(
+            BigInt(0),
+            '0xinvalid',
+            BigInt(0)
+          )
+        ).rejects.toThrow(commonErrorMessage.wrongAddressFormat)
+      })
+      it('failure - pool id does not exist', async () => {
+        await expect(
+          provider.contract.liquidateUserPosition(
+            MAX_BIGINT,
+            TESTING_PUBLIC_KEY,
+            BigInt(0)
+          )
+        ).rejects.toThrow(poolCommonErrorMessage.noExistPoolId(MAX_BIGINT))
+      })
+      it('failure - the pool is not closed', async () => {
+        await expect(
+          provider.contract.liquidateUserPosition(
+            BigInt(6),
+            TESTING_PUBLIC_KEY,
+            BigInt(0)
+          )
+        ).rejects.toThrow(ecpErrorMessage.poolIsNotClosed)
+      })
+      it('failure - borrow id does not exist', async () => {
+        await expect(
+          provider.contract.liquidateUserPosition(
+            BigInt(7),
+            TESTING_PUBLIC_KEY,
+            MAX_BIGINT
+          )
+        ).rejects.toThrow(ecpErrorMessage.noExistBorrowId(MAX_BIGINT))
+      })
+      it('failure - borrow already repaid', async () => {
+        await expect(
+          provider.contract.liquidateUserPosition(
+            BigInt(7),
+            TESTING_PUBLIC_KEY,
+            BigInt(0)
+          )
+        ).rejects.toThrow(ecpErrorMessage.borrowAlreadyRepaid)
       })
     })
   })

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'ethers'
 
-import { Pools } from '../src/pools'
+import { ERC20CollateralPool, Pools } from '../src/pools'
 import { SelfProvider } from '../src/provider'
 import { Staking } from '../src/staking/staking'
 import { CollateralToken } from '../src/types/pools'
@@ -181,7 +181,7 @@ export const getRandomERC20Collaterals = (
 }
 
 export const setPause = async (
-  provider: SelfProvider<Pools | Staking>,
+  provider: SelfProvider<Pools | Staking | ERC20CollateralPool>,
   value: boolean
 ) => {
   const isPaused = await provider.contract.isPaused()


### PR DESCRIPTION
## Support the erc20 collateral pool contract version

## Description

### Summary

- Modify `ERC20CollateralPool` to support the new values of `minBorrow`, `minLended` and `maxLended`

### Changes

- Mirror the smart contract validation changes into the `ERC20CollateralPool` class
- Update the abi of the last version of the erc20 collateral pool smart contract
- Add new test cases in the `addPool`, `lend` and `borrow` functions
- Support `pause` and `unpause` function in the `ERC20CollateralPool` class
- Convert time from milliseconds to seconds before dates comparisons

## Related Issue

- Resolves #225
- Resolves #227 

## How Has This Been Tested?

Add new test cases, and check it is possible to create a new pool, and perform the actions of lend and borrow taking into account the new configuration

![image](https://github.com/user-attachments/assets/454bfafb-c8ef-479e-809c-6122d5e3b0a2)
![image](https://github.com/user-attachments/assets/23447304-88cf-494f-9f60-b9e5f11b4b33)
