### PR TITLE
feat: support buyback contract #230

### DIFF
--- a/.changeset/big-penguins-scream.md
+++ b/.changeset/big-penguins-scream.md
@@ -1,0 +1,5 @@
+---
+"@defactor/defactor-sdk": patch
+---
+
+Add support to multiple contract actions for the `buyback` contract

--- a/src/artifacts/Buyback.json
+++ b/src/artifacts/Buyback.json
@@ -1,0 +1,692 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "Buyback",
+  "sourceName": "contracts/buyback.sol",
+  "abi": [
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "usdcAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "factrAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "id",
+          "type": "uint256"
+        }
+      ],
+      "name": "BuybackCall",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "usdcAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "factrAmount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "id",
+          "type": "uint256"
+        }
+      ],
+      "name": "CustomBuybackCall",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "Id",
+          "type": "uint256"
+        }
+      ],
+      "name": "CustomWithdraw",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "Id",
+          "type": "uint256"
+        }
+      ],
+      "name": "Withdraw",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "BUY_FREQUENCY",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "FACTR",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "MAX_LIQUIDITY_SLIPPAGE",
+      "outputs": [
+        {
+          "internalType": "uint16",
+          "name": "",
+          "type": "uint16"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "ONE_HUNDRED",
+      "outputs": [
+        {
+          "internalType": "uint32",
+          "name": "",
+          "type": "uint32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "ONE_THOUSAND",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "POOL_1_FEE",
+      "outputs": [
+        {
+          "internalType": "uint24",
+          "name": "",
+          "type": "uint24"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "POOL_2_FEE",
+      "outputs": [
+        {
+          "internalType": "uint24",
+          "name": "",
+          "type": "uint24"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "RECOVERER",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "TEN_THOUSAND",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "THREE_HUNDRED",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "USDC",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "WETH",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "buyback",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "id",
+          "type": "uint256"
+        }
+      ],
+      "name": "buybackWithdraw",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "buybacks",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "timeLocked",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint256",
+          "name": "buyAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "spendAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "withdrawn",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "pool1",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "pool2",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "usdcAmount",
+          "type": "uint256"
+        }
+      ],
+      "name": "calculateOptimalAmount",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "usdcAmount",
+          "type": "uint256"
+        },
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "bps",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct IBuyback.BuybackAmounts[]",
+          "name": "collectionArray",
+          "type": "tuple[]"
+        },
+        {
+          "components": [
+            {
+              "internalType": "address",
+              "name": "account",
+              "type": "address"
+            },
+            {
+              "internalType": "uint256",
+              "name": "bps",
+              "type": "uint256"
+            }
+          ],
+          "internalType": "struct IBuyback.BuybackAmounts[]",
+          "name": "distributionArray",
+          "type": "tuple[]"
+        }
+      ],
+      "name": "customBuyback",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "id",
+          "type": "uint256"
+        }
+      ],
+      "name": "customBuybackWithdraw",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "name": "customBuybacks",
+      "outputs": [
+        {
+          "internalType": "uint64",
+          "name": "timeLocked",
+          "type": "uint64"
+        },
+        {
+          "internalType": "uint256",
+          "name": "buyAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "spendAmount",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "withdrawn",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "tokenIn",
+          "type": "address"
+        },
+        {
+          "internalType": "uint128",
+          "name": "amountIn",
+          "type": "uint128"
+        },
+        {
+          "internalType": "address",
+          "name": "tokenOut",
+          "type": "address"
+        },
+        {
+          "internalType": "uint32",
+          "name": "secondsAgo",
+          "type": "uint32"
+        },
+        {
+          "internalType": "address",
+          "name": "pool",
+          "type": "address"
+        }
+      ],
+      "name": "estimateAmountOut",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "amountOut",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "fromId",
+          "type": "uint256"
+        }
+      ],
+      "name": "fetchActiveCustomLocks",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint64",
+              "name": "timeLocked",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint256",
+              "name": "buyAmount",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "spendAmount",
+              "type": "uint256"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "account",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "bps",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IBuyback.BuybackAmounts[]",
+              "name": "distributionArray",
+              "type": "tuple[]"
+            },
+            {
+              "components": [
+                {
+                  "internalType": "address",
+                  "name": "account",
+                  "type": "address"
+                },
+                {
+                  "internalType": "uint256",
+                  "name": "bps",
+                  "type": "uint256"
+                }
+              ],
+              "internalType": "struct IBuyback.BuybackAmounts[]",
+              "name": "collectionArray",
+              "type": "tuple[]"
+            },
+            {
+              "internalType": "bool",
+              "name": "withdrawn",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct IBuyback.CustomBuybackStruct[]",
+          "name": "",
+          "type": "tuple[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "fromId",
+          "type": "uint256"
+        }
+      ],
+      "name": "fetchActiveLocks",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint64",
+              "name": "timeLocked",
+              "type": "uint64"
+            },
+            {
+              "internalType": "uint256",
+              "name": "buyAmount",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "spendAmount",
+              "type": "uint256"
+            },
+            {
+              "internalType": "bool",
+              "name": "withdrawn",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct IBuyback.BuybackStruct[]",
+          "name": "",
+          "type": "tuple[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "recoverer",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "buyFrequency",
+          "type": "uint256"
+        },
+        {
+          "internalType": "address[]",
+          "name": "vaults",
+          "type": "address[]"
+        },
+        {
+          "internalType": "uint16",
+          "name": "maxLiquiditySlippage",
+          "type": "uint16"
+        }
+      ],
+      "name": "initialize",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        }
+      ],
+      "name": "recoverERC20",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "uniswapFactory",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "uniswapRouter",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "vault1",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "vault2",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "vault3",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "vault4",
+      "outputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    }
+  ],
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/src/artifacts/index.ts
+++ b/src/artifacts/index.ts
@@ -1,4 +1,5 @@
 import miscAdminPools from './AdminPools.json'
+import miscBuyback from './Buyback.json'
 import miscErc20 from './ERC20.json'
 import miscErc20CollateralPool from './ERC20CollateralPool.json'
 import miscErc20CollateralPoolToplend from './ERC20CollateralPoolToplend.json'
@@ -11,5 +12,6 @@ export {
   miscAdminPools,
   miscErc20,
   miscStaking,
-  miscErc20CollateralPoolToplend
+  miscErc20CollateralPoolToplend,
+  miscBuyback
 }

--- a/src/base-classes/base-contract.ts
+++ b/src/base-classes/base-contract.ts
@@ -1,40 +1,23 @@
-import { Contract, ethers } from 'ethers'
+import { ethers } from 'ethers'
 
 import { miscErc20CollateralPool } from '../artifacts'
 import { commonErrorMessage } from '../errors'
 import { Abi, PrivateKey, RoleOption } from '../types/types'
 import { Role } from '../utilities/util'
+import { CoreContract } from './core-contract'
 
 export type BaseContractConstructorParams = ConstructorParameters<
   typeof BaseContract
 >
 
-export abstract class BaseContract {
-  readonly address: string
-  readonly jsonRpcProvider: ethers.JsonRpcProvider
-  readonly abi: Abi
-  readonly contract: Contract
-  readonly signer: ethers.Wallet | null
-  readonly apiUrl: string
-
+export abstract class BaseContract extends CoreContract {
   constructor(
     address: string,
     apiUrl: string,
     privateKey: PrivateKey | null,
     abi: Abi
   ) {
-    this.contract = new Contract(
-      address,
-      abi || miscErc20CollateralPool.abi,
-      new ethers.JsonRpcProvider(apiUrl)
-    )
-    this.address = address
-    this.jsonRpcProvider = new ethers.JsonRpcProvider(apiUrl)
-    this.abi = abi
-    this.apiUrl = apiUrl
-    this.signer = privateKey
-      ? new ethers.Wallet(privateKey, new ethers.JsonRpcProvider(apiUrl))
-      : null
+    super(address, apiUrl, privateKey, abi || miscErc20CollateralPool.abi)
   }
 
   protected _checkIsAdmin = async () => {

--- a/src/base-classes/base-provider.ts
+++ b/src/base-classes/base-provider.ts
@@ -1,9 +1,10 @@
+import { Buyback } from '../buyback/buyback'
 import { ERC20CollateralPool } from '../pools/erc20-collateral-pool'
 import { Pools as PoolsClass } from '../pools/pools'
 import { Staking } from '../staking/staking'
 
 export abstract class BaseProvider<
-  T extends PoolsClass | ERC20CollateralPool | Staking
+  T extends PoolsClass | ERC20CollateralPool | Staking | Buyback
 > {
   readonly contract: T
 

--- a/src/base-classes/core-contract.ts
+++ b/src/base-classes/core-contract.ts
@@ -1,0 +1,36 @@
+import { Contract, ethers } from 'ethers'
+
+import { Abi, PrivateKey } from '../types/types'
+
+export type CoreContractConstructorParams = ConstructorParameters<
+  typeof CoreContract
+>
+
+export abstract class CoreContract {
+  readonly address: string
+  readonly jsonRpcProvider: ethers.JsonRpcProvider
+  readonly abi: Abi
+  readonly contract: Contract
+  readonly signer: ethers.Wallet | null
+  readonly apiUrl: string
+
+  constructor(
+    address: string,
+    apiUrl: string,
+    privateKey: PrivateKey | null,
+    abi: Abi
+  ) {
+    this.contract = new Contract(
+      address,
+      abi,
+      new ethers.JsonRpcProvider(apiUrl)
+    )
+    this.address = address
+    this.jsonRpcProvider = new ethers.JsonRpcProvider(apiUrl)
+    this.abi = abi
+    this.apiUrl = apiUrl
+    this.signer = privateKey
+      ? new ethers.Wallet(privateKey, new ethers.JsonRpcProvider(apiUrl))
+      : null
+  }
+}

--- a/src/base-classes/index.ts
+++ b/src/base-classes/index.ts
@@ -1,2 +1,3 @@
 export * from './base-contract'
 export * from './base-provider'
+export * from './core-contract'

--- a/src/buyback/buyback.ts
+++ b/src/buyback/buyback.ts
@@ -1,18 +1,22 @@
 import { ContractTransaction, TransactionResponse, ethers } from 'ethers'
 
 import { miscStaking } from '../artifacts'
-import { BaseContract } from '../base-classes'
+import { CoreContract } from '../base-classes'
 import { buybackErrorMessage, commonErrorMessage } from '../errors'
 import {
   BuybackAmounts,
   BuybackStruct,
+  Constants,
   CustomBuybackStruct,
   Functions,
   Views
 } from '../types/buyback'
 import { Abi, PrivateKey } from '../types/types'
 
-export class Buyback extends BaseContract implements Functions, Views {
+export class Buyback
+  extends CoreContract
+  implements Functions, Views, Constants
+{
   readonly ONE_HUNDRED = BigInt(100)
   readonly THREE_HUNDRED = BigInt(300)
   readonly ONE_THOUSAND = BigInt(1_000)
@@ -25,6 +29,62 @@ export class Buyback extends BaseContract implements Functions, Views {
     abi?: Abi
   ) {
     super(address, apiUrl, privateKey, abi || miscStaking.abi)
+  }
+
+  async getVault1(): Promise<string> {
+    return await this.contract.vault1()
+  }
+
+  async getVault2(): Promise<string> {
+    return await this.contract.vault2()
+  }
+
+  async getVault3(): Promise<string> {
+    return await this.contract.vault3()
+  }
+
+  async getVault4(): Promise<string> {
+    return await this.contract.vault4()
+  }
+
+  async getUniswapFactory(): Promise<string> {
+    return await this.contract.uniswapFactory()
+  }
+
+  async getUniswapRouter(): Promise<string> {
+    return await this.contract.uniswapRouter()
+  }
+
+  async getFACTR(): Promise<string> {
+    return await this.contract.FACTR()
+  }
+
+  async getUSDC(): Promise<string> {
+    return await this.contract.USDC()
+  }
+
+  async getWETH(): Promise<string> {
+    return await this.contract.WETH()
+  }
+
+  async getPool1Fee(): Promise<bigint> {
+    return await this.contract.POOL_1_FEE()
+  }
+
+  async getPool2Fee(): Promise<bigint> {
+    return await this.contract.POOL_2_FEE()
+  }
+
+  async getBuyFrequency(): Promise<bigint> {
+    return await this.contract.BUY_FREQUENCY()
+  }
+
+  async getMaxLiquiditySlippage(): Promise<bigint> {
+    return await this.contract.MAX_LIQUIDITY_SLIPPAGE()
+  }
+
+  async getRecovererAddress(): Promise<string> {
+    return await this.contract.RECOVERER()
   }
 
   async fetchActiveLocks(fromId: bigint): Promise<Array<BuybackStruct>> {

--- a/src/buyback/buyback.ts
+++ b/src/buyback/buyback.ts
@@ -349,13 +349,28 @@ export class Buyback
   }
 
   async recoverERC20(
-    address: string
+    token: string
   ): Promise<ContractTransaction | TransactionResponse> {
-    if (!ethers.isAddress(address)) {
+    if (!ethers.isAddress(token)) {
       throw new Error(commonErrorMessage.wrongAddressFormat)
     }
 
-    const pop = await this.contract.recoverERC20.populateTransaction(address)
+    if (this.signer) {
+      const recoverer = await this.getRecovererAddress()
+
+      if (this.signer.address !== recoverer) {
+        throw new Error(buybackErrorMessage.addressIsNotRecoverer)
+      }
+    }
+
+    const factr = await this.getFACTR()
+    const usdc = await this.getUSDC()
+
+    if (token === factr || token === usdc) {
+      throw new Error(commonErrorMessage.invalidToken)
+    }
+
+    const pop = await this.contract.recoverERC20.populateTransaction(token)
 
     return this.signer ? await this.signer.sendTransaction(pop) : pop
   }

--- a/src/buyback/buyback.ts
+++ b/src/buyback/buyback.ts
@@ -1,0 +1,166 @@
+import { ContractTransaction, TransactionResponse, ethers } from 'ethers'
+
+import { miscStaking } from '../artifacts'
+import { BaseContract } from '../base-classes'
+import { buybackErrorMessage, commonErrorMessage } from '../errors'
+import {
+  BuybackAmounts,
+  BuybackStruct,
+  CustomBuybackStruct,
+  Functions,
+  Views
+} from '../types/buyback'
+import { Abi, PrivateKey } from '../types/types'
+
+export class Buyback extends BaseContract implements Functions, Views {
+  readonly ONE_HUNDRED = BigInt(100)
+  readonly THREE_HUNDRED = BigInt(300)
+  readonly ONE_THOUSAND = BigInt(1_000)
+  readonly TEN_THOUSAND = BigInt(10_000)
+
+  constructor(
+    address: string,
+    apiUrl: string,
+    privateKey: PrivateKey | null,
+    abi?: Abi
+  ) {
+    super(address, apiUrl, privateKey, abi || miscStaking.abi)
+  }
+
+  async fetchActiveLocks(fromId: bigint): Promise<Array<BuybackStruct>> {
+    if (fromId < 0) {
+      throw new Error(buybackErrorMessage.nonNegativeBuybackId)
+    }
+
+    return await this.contract.fetchActiveLocks(fromId)
+  }
+
+  async fetchActiveCustomLocks(
+    fromId: bigint
+  ): Promise<Array<CustomBuybackStruct>> {
+    if (fromId < 0) {
+      throw new Error(buybackErrorMessage.nonNegativeBuybackId)
+    }
+
+    return await this.contract.fetchActiveCustomLocks(fromId)
+  }
+
+  async calculateOptimalAmount(
+    pool1: string,
+    pool2: string,
+    usdcAmount: bigint
+  ): Promise<bigint> {
+    if (usdcAmount <= 0) {
+      throw new Error(buybackErrorMessage.noNegativeAmountOrZero)
+    }
+
+    if (!ethers.isAddress(pool1) || !ethers.isAddress(pool2)) {
+      throw new Error(commonErrorMessage.wrongAddressFormat)
+    }
+
+    return await this.contract.calculateOptimalAmount(pool1, pool2, usdcAmount)
+  }
+
+  async estimateAmountOut(
+    tokenIn: string,
+    amountIn: bigint,
+    tokenOut: string,
+    secondsAgo: bigint,
+    pool: string
+  ): Promise<bigint> {
+    if (
+      !ethers.isAddress(tokenIn) ||
+      !ethers.isAddress(tokenOut) ||
+      !ethers.isAddress(pool)
+    ) {
+      throw new Error(commonErrorMessage.wrongAddressFormat)
+    }
+
+    if (amountIn <= 0) {
+      throw new Error(buybackErrorMessage.noNegativeAmountOrZero)
+    }
+
+    if (secondsAgo <= 0) {
+      throw new Error(buybackErrorMessage.noNegativeSecondsOrZero)
+    }
+
+    return await this.contract.estimateAmountOut(
+      tokenIn,
+      amountIn,
+      tokenOut,
+      secondsAgo,
+      pool
+    )
+  }
+
+  async buyback(): Promise<ContractTransaction | TransactionResponse> {
+    const pop = await this.contract.buyback.populateTransaction()
+
+    return this.signer ? await this.signer.sendTransaction(pop) : pop
+  }
+
+  async buybackWithdraw(
+    id: bigint
+  ): Promise<ContractTransaction | TransactionResponse> {
+    if (id < 0) {
+      throw new Error(buybackErrorMessage.nonNegativeBuybackId)
+    }
+
+    const pop = await this.contract.buybackWithdraw.populateTransaction(id)
+
+    return this.signer ? await this.signer.sendTransaction(pop) : pop
+  }
+
+  async customBuyback(
+    usdcAmount: bigint,
+    collectionArray: Array<BuybackAmounts>,
+    distributionArray: Array<BuybackAmounts>
+  ): Promise<ContractTransaction | TransactionResponse> {
+    if (usdcAmount <= 0) {
+      throw new Error(buybackErrorMessage.noNegativeAmountOrZero)
+    }
+
+    for (const buybackAmount of collectionArray.concat(distributionArray)) {
+      if (!ethers.isAddress(buybackAmount.account)) {
+        throw new Error(commonErrorMessage.wrongAddressFormat)
+      }
+
+      if (buybackAmount.bps < 0) {
+        throw new Error(buybackErrorMessage.noNegativeBps)
+      }
+    }
+
+    const pop = await this.contract.customBuyback.populateTransaction(
+      usdcAmount,
+      collectionArray,
+      distributionArray
+    )
+
+    return this.signer ? await this.signer.sendTransaction(pop) : pop
+  }
+
+  async customBuybackWithdraw(
+    id: bigint
+  ): Promise<ContractTransaction | TransactionResponse> {
+    if (id < 0) {
+      throw new Error(buybackErrorMessage.nonNegativeBuybackId)
+    }
+
+    const pop =
+      await this.contract.customBuybackWithdraw.populateTransaction(id)
+
+    return this.signer ? await this.signer.sendTransaction(pop) : pop
+  }
+
+  async recoverERC20(
+    address: string
+  ): Promise<ContractTransaction | TransactionResponse> {
+    if (!ethers.isAddress(address)) {
+      throw new Error(commonErrorMessage.wrongAddressFormat)
+    }
+
+    const pop = await this.contract.recoverERC20.populateTransaction(address)
+
+    return this.signer ? await this.signer.sendTransaction(pop) : pop
+  }
+}

--- a/src/buyback/buyback.ts
+++ b/src/buyback/buyback.ts
@@ -1,6 +1,6 @@
 import { ContractTransaction, TransactionResponse, ethers } from 'ethers'
 
-import { miscStaking } from '../artifacts'
+import { miscBuyback } from '../artifacts'
 import { CoreContract } from '../base-classes'
 import { buybackErrorMessage, commonErrorMessage } from '../errors'
 import {
@@ -28,7 +28,7 @@ export class Buyback
     privateKey: PrivateKey | null,
     abi?: Abi
   ) {
-    super(address, apiUrl, privateKey, abi || miscStaking.abi)
+    super(address, apiUrl, privateKey, abi || miscBuyback.abi)
   }
 
   async getVault1(): Promise<string> {

--- a/src/buyback/index.ts
+++ b/src/buyback/index.ts
@@ -1,0 +1,1 @@
+export * from './buyback'

--- a/src/errors/error-messages.ts
+++ b/src/errors/error-messages.ts
@@ -1,7 +1,9 @@
 export const commonErrorMessage = {
   contractIsPaused: 'The contract is paused',
   addressIsNotAdmin: 'Sender address is not admin',
-  wrongAddressFormat: `Address does not follow the ethereum address format`
+  wrongAddressFormat: `Address does not follow the ethereum address format`,
+  nonGreaterThan: (valueName: string, maxValue: string) =>
+    `The ${valueName} value cannot be greater than ${maxValue}`
 }
 
 export const poolCommonErrorMessage = {
@@ -99,7 +101,15 @@ export const stakingErrorMessage = {
 
 export const buybackErrorMessage = {
   nonNegativeBuybackId: 'Buyback id cannot be negative',
-  noNegativeAmountOrZero: 'Amount cannot be negative or 0',
-  noNegativeSecondsOrZero: 'Seconds cannot be negative or 0',
-  noNegativeBps: 'Bps cannot be negative or 0'
+  nonNegativeAmountOrZero: 'Amount cannot be negative or 0',
+  nonNegativeSecondsOrZero: 'Seconds cannot be negative or 0',
+  nonNegativeOrZeroBps: 'Bps cannot be negative or 0',
+  nonExistBuybackId: (buybackId: bigint) =>
+    `Buyback id ${buybackId.toString()} does not exist`,
+  nonExistCustomBuybackId: (buybackId: bigint) =>
+    `Custom buyback id ${buybackId.toString()} does not exist`,
+  buybackConstraint: 'USDC Balance should be at least 1000',
+  collectionBpsConstraint: 'Sum of BPSs should equal 100%',
+  unlockPeriodNotFinished: 'Unlock period not finished',
+  alreadyWithdrawn: 'Unlock already withdrawn'
 }

--- a/src/errors/error-messages.ts
+++ b/src/errors/error-messages.ts
@@ -3,7 +3,8 @@ export const commonErrorMessage = {
   addressIsNotAdmin: 'Sender address is not admin',
   wrongAddressFormat: `Address does not follow the ethereum address format`,
   nonGreaterThan: (valueName: string, maxValue: string) =>
-    `The ${valueName} value cannot be greater than ${maxValue}`
+    `The ${valueName} value cannot be greater than ${maxValue}`,
+  invalidToken: 'Invalid token address'
 }
 
 export const poolCommonErrorMessage = {
@@ -111,5 +112,6 @@ export const buybackErrorMessage = {
   buybackConstraint: 'USDC Balance should be at least 1000',
   collectionBpsConstraint: 'Sum of BPSs should equal 100%',
   unlockPeriodNotFinished: 'Unlock period not finished',
-  alreadyWithdrawn: 'Unlock already withdrawn'
+  alreadyWithdrawn: 'Unlock already withdrawn',
+  addressIsNotRecoverer: 'Sender address is not recoverer address'
 }

--- a/src/errors/error-messages.ts
+++ b/src/errors/error-messages.ts
@@ -96,3 +96,10 @@ export const stakingErrorMessage = {
   nonNegativeIndexId: 'Neither Index nor Id can be negative',
   nonNegativeDates: 'Neither staking nor reward end date can be negative'
 }
+
+export const buybackErrorMessage = {
+  nonNegativeBuybackId: 'Buyback id cannot be negative',
+  noNegativeAmountOrZero: 'Amount cannot be negative or 0',
+  noNegativeSecondsOrZero: 'Seconds cannot be negative or 0',
+  noNegativeBps: 'Bps cannot be negative or 0'
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import * as Artifacts from './artifacts'
+import { Buyback } from './buyback'
 import {
   AdminPools,
   ERC20CollateralPool,
@@ -12,11 +13,13 @@ import { Erc20 } from './utilities/erc20'
 import * as generics from './utilities/generics'
 import * as util from './utilities/util'
 
+export * as TypesBuyback from './types/buyback'
 export * as TypesErc20CollateralPool from './types/erc20-collateral-token'
 export * as TypesErc20CollateralPoolToplend from './types/erc20-collateral-pool-toplend'
 export * as TypesPool from './types/pools'
 export * as TypesStaking from './types/staking'
 export * as Types from './types/types'
+export * from './base-classes/core-contract'
 export * from './base-classes/base-contract'
 export * from './base-classes/base-provider'
 
@@ -25,6 +28,7 @@ const Utilities = { util, generics, Erc20 }
 export {
   Artifacts,
   AssistedProvider,
+  Buyback,
   SelfProvider,
   Utilities,
   ERC20CollateralPool,
@@ -38,6 +42,7 @@ export {
 export const DefactorSDK = {
   Artifacts,
   AssistedProvider,
+  Buyback,
   SelfProvider,
   Utilities,
   ERC20CollateralPool,

--- a/src/provider/assisted.provider.ts
+++ b/src/provider/assisted.provider.ts
@@ -1,22 +1,27 @@
 import { miscErc20CollateralPool } from '../artifacts'
 import { BaseProvider } from '../base-classes'
+import { Buyback } from '../buyback/buyback'
 import { ERC20CollateralPool } from '../pools/erc20-collateral-pool'
 import { Pools as PoolsClass } from '../pools/pools'
 import { Staking } from '../staking/staking'
 import {
   Abi,
+  BuybackConstructorParams,
   ERC20CollateralPoolConstructorParams,
   PoolsConstructorParams
 } from '../types/types'
 
 export class AssistedProvider<
-  T extends PoolsClass | ERC20CollateralPool | Staking
+  T extends PoolsClass | ERC20CollateralPool | Staking | Buyback
 > extends BaseProvider<T> {
   readonly abi: Abi
 
   constructor(
     contractBuilder: new (
-      ...args: PoolsConstructorParams | ERC20CollateralPoolConstructorParams
+      ...args:
+        | PoolsConstructorParams
+        | ERC20CollateralPoolConstructorParams
+        | BuybackConstructorParams
     ) => T,
     address: string,
     apiUrl: string,

--- a/src/provider/self.provider.ts
+++ b/src/provider/self.provider.ts
@@ -1,9 +1,11 @@
 import { BaseProvider } from '../base-classes'
+import { Buyback } from '../buyback/buyback'
 import { ERC20CollateralPool } from '../pools/erc20-collateral-pool'
 import { Pools as PoolsClass } from '../pools/pools'
 import { Staking } from '../staking/staking'
 import {
   Abi,
+  BuybackConstructorParams,
   ERC20CollateralPoolConstructorParams,
   PoolsConstructorParams,
   PrivateKey,
@@ -11,7 +13,7 @@ import {
 } from '../types/types'
 
 export class SelfProvider<
-  T extends PoolsClass | ERC20CollateralPool | Staking
+  T extends PoolsClass | ERC20CollateralPool | Staking | Buyback
 > extends BaseProvider<T> {
   constructor(
     contractBuilder: new (
@@ -19,6 +21,7 @@ export class SelfProvider<
         | PoolsConstructorParams
         | ERC20CollateralPoolConstructorParams
         | StakingConstructorParams
+        | BuybackConstructorParams
     ) => T,
     address: string,
     apiUrl: string,

--- a/src/types/buyback.ts
+++ b/src/types/buyback.ts
@@ -51,3 +51,20 @@ export interface Views {
     pool: string
   ): Promise<bigint>
 }
+
+export interface Constants {
+  getVault1(): Promise<string>
+  getVault2(): Promise<string>
+  getVault3(): Promise<string>
+  getVault4(): Promise<string>
+  getUniswapFactory(): Promise<string>
+  getUniswapRouter(): Promise<string>
+  getFACTR(): Promise<string>
+  getUSDC(): Promise<string>
+  getWETH(): Promise<string>
+  getPool1Fee(): Promise<bigint>
+  getPool2Fee(): Promise<bigint>
+  getBuyFrequency(): Promise<bigint>
+  getMaxLiquiditySlippage(): Promise<bigint>
+  getRecovererAddress(): Promise<string>
+}

--- a/src/types/buyback.ts
+++ b/src/types/buyback.ts
@@ -1,0 +1,53 @@
+import { ethers } from 'ethers'
+
+export type BuybackStruct = {
+  timeLocked: bigint
+  buyAmount: bigint
+  spendAmount: bigint
+  withdrawn: boolean
+}
+
+export type BuybackAmounts = {
+  account: string
+  bps: bigint
+}
+
+export type CustomBuybackStruct = BuybackStruct & {
+  distributionArray: Array<BuybackAmounts>
+  collectionArray: Array<BuybackAmounts>
+}
+
+export interface Functions {
+  buyback(): Promise<ethers.ContractTransaction | ethers.TransactionResponse>
+  buybackWithdraw(
+    id: bigint
+  ): Promise<ethers.ContractTransaction | ethers.TransactionResponse>
+  customBuyback(
+    usdcAmount: bigint,
+    collectionArray: Array<BuybackAmounts>,
+    distributionArray: Array<BuybackAmounts>
+  ): Promise<ethers.ContractTransaction | ethers.TransactionResponse>
+  customBuybackWithdraw(
+    id: bigint
+  ): Promise<ethers.ContractTransaction | ethers.TransactionResponse>
+  recoverERC20(
+    token: string
+  ): Promise<ethers.ContractTransaction | ethers.TransactionResponse>
+}
+
+export interface Views {
+  fetchActiveLocks(fromId: bigint): Promise<Array<BuybackStruct>>
+  fetchActiveCustomLocks(fromId: bigint): Promise<Array<CustomBuybackStruct>>
+  calculateOptimalAmount(
+    pool1: string,
+    pool2: string,
+    usdcAmount: bigint
+  ): Promise<bigint>
+  estimateAmountOut(
+    tokenIn: string,
+    amountIn: bigint,
+    tokenOut: string,
+    secondsAgo: bigint,
+    pool: string
+  ): Promise<bigint>
+}

--- a/src/types/types.ts
+++ b/src/types/types.ts
@@ -1,5 +1,6 @@
 import { ethers } from 'ethers'
 
+import { Buyback } from '../buyback'
 import { ERC20CollateralPool } from '../pools/erc20-collateral-pool'
 import { Pools } from '../pools/pools'
 import { Staking } from '../staking/staking'
@@ -12,6 +13,8 @@ export type ERC20CollateralPoolConstructorParams = ConstructorParameters<
 export type PoolsConstructorParams = ConstructorParameters<typeof Pools>
 
 export type StakingConstructorParams = ConstructorParameters<typeof Staking>
+
+export type BuybackConstructorParams = ConstructorParameters<typeof Buyback>
 
 export type Abi = ethers.Interface | ethers.InterfaceAbi
 

--- a/src/utilities/erc20.ts
+++ b/src/utilities/erc20.ts
@@ -23,6 +23,10 @@ export class Erc20 extends BaseContract {
     return await this.contract.allowance(owner, spender)
   }
 
+  async decimals(): Promise<bigint> {
+    return await this.contract.decimals()
+  }
+
   async approve(
     address: string,
     amount: bigint

--- a/test/integration/self-provider-buyback.test.ts
+++ b/test/integration/self-provider-buyback.test.ts
@@ -1,4 +1,4 @@
-import { ethers } from 'ethers'
+import { ethers, isError } from 'ethers'
 import timekeeper from 'timekeeper'
 
 import { Erc20 } from '../../src'
@@ -9,6 +9,8 @@ import {
   ADMIN_TESTING_PRIVATE_KEY,
   BUYBACK_CONTRACT_ADDRESS,
   MAX_BIGINT,
+  ONE_DAY_SEC,
+  ONE_YEAR_SEC,
   loadEnv
 } from '../test-util'
 
@@ -58,6 +60,7 @@ describe('SelfProvider - Buyback', () => {
     })
   })
 
+  // TODO - Add success test cases https://github.com/defactor-com/sdk/issues/231 #231
   describe('Functions', () => {
     describe('buyback()', () => {
       it.skip('failure - usdc balance is is less than 1000', async () => {
@@ -76,6 +79,23 @@ describe('SelfProvider - Buyback', () => {
         await expect(
           provider.contract.buybackWithdraw(BigInt(0))
         ).rejects.toThrow(buybackErrorMessage.unlockPeriodNotFinished)
+      })
+      it.skip('success - buyback withdraw', async () => {
+        const buyback = await provider.contract.getBuyback(BigInt(0))
+        const dateAfterLock =
+          (Number(buyback.timeLocked) + ONE_YEAR_SEC + ONE_DAY_SEC) * 1000
+
+        timekeeper.travel(new Date(dateAfterLock))
+
+        expect.assertions(1)
+
+        try {
+          await provider.contract.buybackWithdraw(BigInt(0))
+        } catch (error) {
+          expect(isError(error, 'CALL_EXCEPTION')).toBeTruthy()
+        }
+
+        timekeeper.reset()
       })
     })
     describe('customBuyback()', () => {
@@ -161,6 +181,25 @@ describe('SelfProvider - Buyback', () => {
         await expect(
           provider.contract.customBuybackWithdraw(BigInt(0))
         ).rejects.toThrow(buybackErrorMessage.unlockPeriodNotFinished)
+      })
+      it.skip('success - buyback withdraw', async () => {
+        const customBuyback = await provider.contract.getCustomBuyback(
+          BigInt(0)
+        )
+        const dateAfterLock =
+          (Number(customBuyback.timeLocked) + ONE_YEAR_SEC + ONE_DAY_SEC) * 1000
+
+        timekeeper.travel(new Date(dateAfterLock))
+
+        expect.assertions(1)
+
+        try {
+          await provider.contract.customBuybackWithdraw(BigInt(0))
+        } catch (error) {
+          expect(isError(error, 'CALL_EXCEPTION')).toBeTruthy()
+        }
+
+        timekeeper.reset()
       })
     })
   })

--- a/test/integration/self-provider-buyback.test.ts
+++ b/test/integration/self-provider-buyback.test.ts
@@ -1,0 +1,113 @@
+import { ethers } from 'ethers'
+import timekeeper from 'timekeeper'
+
+import { Buyback } from '../../src/buyback'
+import { SelfProvider } from '../../src/provider'
+import {
+  ADMIN_TESTING_PRIVATE_KEY,
+  BUYBACK_CONTRACT_ADDRESS,
+  loadEnv
+} from '../test-util'
+
+jest.setTimeout(300000)
+
+describe('SelfProvider - Buyback', () => {
+  let provider: SelfProvider<Buyback>
+  let signerAddress: string
+
+  beforeAll(async () => {
+    await loadEnv()
+
+    if (!process.env.PROVIDER_URL) {
+      throw new Error('PROVIDER_URL is not defined')
+    }
+
+    provider = new SelfProvider(
+      Buyback,
+      BUYBACK_CONTRACT_ADDRESS,
+      process.env.PROVIDER_URL,
+      ADMIN_TESTING_PRIVATE_KEY
+    )
+
+    signerAddress = provider.contract.signer?.address || ''
+
+    if (!signerAddress) {
+      throw new Error('signer address is not defined')
+    }
+  })
+
+  beforeEach(() => {
+    timekeeper.reset()
+  })
+
+  describe('Constant Variables', () => {
+    it('success - one hundred', async () => {
+      expect(provider.contract.ONE_HUNDRED).toBe(BigInt('100'))
+    })
+    it('success - three hundred', async () => {
+      expect(provider.contract.THREE_HUNDRED).toBe(BigInt('300'))
+    })
+    it('success - one thousand', async () => {
+      expect(provider.contract.ONE_THOUSAND).toBe(BigInt('1000'))
+    })
+    it('success - ten thousand', async () => {
+      expect(provider.contract.TEN_THOUSAND).toBe(BigInt('10000'))
+    })
+  })
+
+  describe.skip('Functions', () => {})
+
+  describe('Views', () => {
+    it('success - get pool 1 fee', async () => {
+      expect(await provider.contract.getPool1Fee()).toBe(BigInt('500'))
+    })
+    it('success - get pool 2 fee', async () => {
+      expect(await provider.contract.getPool2Fee()).toBe(BigInt('3000'))
+    })
+    it('success - get vault 1', async () => {
+      const address = await provider.contract.getVault1()
+
+      expect(ethers.isAddress(address)).toBe(true)
+    })
+    it('success - get vault 2', async () => {
+      const address = await provider.contract.getVault2()
+
+      expect(ethers.isAddress(address)).toBe(true)
+    })
+    it('success - get vault 3', async () => {
+      const address = await provider.contract.getVault3()
+
+      expect(ethers.isAddress(address)).toBe(true)
+    })
+    it('success - get vault 4', async () => {
+      const address = await provider.contract.getVault4()
+
+      expect(ethers.isAddress(address)).toBe(true)
+    })
+    it('success - get uniswap factory', async () => {
+      const address = await provider.contract.getUniswapFactory()
+
+      expect(ethers.isAddress(address)).toBe(true)
+    })
+    it('success - get uniswap router', async () => {
+      const address = await provider.contract.getUniswapRouter()
+
+      expect(ethers.isAddress(address)).toBe(true)
+    })
+    it('success - get factr', async () => {
+      const address = await provider.contract.getFACTR()
+
+      expect(ethers.isAddress(address)).toBe(true)
+    })
+    it('success - get usdc', async () => {
+      const address = await provider.contract.getUSDC()
+
+      expect(ethers.isAddress(address)).toBe(true)
+    })
+    it('success - get weth', async () => {
+      const address = await provider.contract.getWETH()
+
+      expect(ethers.isAddress(address)).toBe(true)
+    })
+  })
+})

--- a/test/integration/self-provider-buyback.test.ts
+++ b/test/integration/self-provider-buyback.test.ts
@@ -72,6 +72,11 @@ describe('SelfProvider - Buyback', () => {
           provider.contract.buybackWithdraw(BigInt(0))
         ).rejects.toThrow(buybackErrorMessage.alreadyWithdrawn)
       })
+      it.skip('failure - unlock period not finished', async () => {
+        await expect(
+          provider.contract.buybackWithdraw(BigInt(0))
+        ).rejects.toThrow(buybackErrorMessage.unlockPeriodNotFinished)
+      })
     })
     describe('customBuyback()', () => {
       it('failure - usdcAmount is negative', async () => {
@@ -86,13 +91,13 @@ describe('SelfProvider - Buyback', () => {
       })
       it('failure - usdcAmount is less than 1000', async () => {
         await expect(
-          provider.contract.customBuyback(BigInt(900000000), [], [])
+          provider.contract.customBuyback(BigInt(900_000000), [], [])
         ).rejects.toThrow(buybackErrorMessage.buybackConstraint)
       })
       it('failure - collection array does not have valid addresses', async () => {
         await expect(
           provider.contract.customBuyback(
-            BigInt(1000000000),
+            BigInt(1000_000000),
             [{ account: '0xinvalid', bps: BigInt(0) }],
             []
           )
@@ -101,7 +106,7 @@ describe('SelfProvider - Buyback', () => {
       it('failure - distribution array does not have valid addresses', async () => {
         await expect(
           provider.contract.customBuyback(
-            BigInt(1000000000),
+            BigInt(1000_000000),
             [],
             [{ account: '0xinvalid', bps: BigInt(0) }]
           )
@@ -110,7 +115,7 @@ describe('SelfProvider - Buyback', () => {
       it('failure - collection array have zero bps', async () => {
         await expect(
           provider.contract.customBuyback(
-            BigInt(1000000000),
+            BigInt(1000_000000),
             [
               { account: signerAddress, bps: BigInt(1) },
               { account: signerAddress, bps: BigInt(1) },
@@ -123,7 +128,7 @@ describe('SelfProvider - Buyback', () => {
       it('failure - collection array have negative bps', async () => {
         await expect(
           provider.contract.customBuyback(
-            BigInt(1000000000),
+            BigInt(1000_000000),
             [
               { account: signerAddress, bps: BigInt(1) },
               { account: signerAddress, bps: BigInt(1) },
@@ -136,10 +141,10 @@ describe('SelfProvider - Buyback', () => {
       it('failure - collection array bps is not 100%', async () => {
         await expect(
           provider.contract.customBuyback(
-            BigInt(1000000000),
+            BigInt(1000_000000),
             [
-              { account: signerAddress, bps: BigInt(8000) },
-              { account: signerAddress, bps: BigInt(1500) }
+              { account: signerAddress, bps: BigInt(80_00) },
+              { account: signerAddress, bps: BigInt(15_00) }
             ],
             []
           )
@@ -151,6 +156,11 @@ describe('SelfProvider - Buyback', () => {
         await expect(
           provider.contract.customBuybackWithdraw(BigInt(0))
         ).rejects.toThrow(buybackErrorMessage.alreadyWithdrawn)
+      })
+      it.skip('failure - unlock period not finished', async () => {
+        await expect(
+          provider.contract.customBuybackWithdraw(BigInt(0))
+        ).rejects.toThrow(buybackErrorMessage.unlockPeriodNotFinished)
       })
     })
   })

--- a/test/integration/self-provider-buyback.test.ts
+++ b/test/integration/self-provider-buyback.test.ts
@@ -3,10 +3,12 @@ import timekeeper from 'timekeeper'
 
 import { Erc20 } from '../../src'
 import { Buyback } from '../../src/buyback'
+import { buybackErrorMessage, commonErrorMessage } from '../../src/errors'
 import { SelfProvider } from '../../src/provider'
 import {
   ADMIN_TESTING_PRIVATE_KEY,
   BUYBACK_CONTRACT_ADDRESS,
+  MAX_BIGINT,
   loadEnv
 } from '../test-util'
 
@@ -56,7 +58,102 @@ describe('SelfProvider - Buyback', () => {
     })
   })
 
-  describe.skip('Functions', () => {})
+  describe('Functions', () => {
+    describe('buyback()', () => {
+      it.skip('failure - usdc balance is is less than 1000', async () => {
+        await expect(provider.contract.buyback()).rejects.toThrow(
+          buybackErrorMessage.buybackConstraint
+        )
+      })
+    })
+    describe('buybackWithdraw()', () => {
+      it.skip('failure - already withdrawn', async () => {
+        await expect(
+          provider.contract.buybackWithdraw(BigInt(0))
+        ).rejects.toThrow(buybackErrorMessage.alreadyWithdrawn)
+      })
+    })
+    describe('customBuyback()', () => {
+      it('failure - usdcAmount is negative', async () => {
+        await expect(
+          provider.contract.customBuyback(BigInt(-1), [], [])
+        ).rejects.toThrow(buybackErrorMessage.nonNegativeAmountOrZero)
+      })
+      it('failure - usdcAmount is zero', async () => {
+        await expect(
+          provider.contract.customBuyback(BigInt(0), [], [])
+        ).rejects.toThrow(buybackErrorMessage.nonNegativeAmountOrZero)
+      })
+      it('failure - usdcAmount is less than 1000', async () => {
+        await expect(
+          provider.contract.customBuyback(BigInt(900000000), [], [])
+        ).rejects.toThrow(buybackErrorMessage.buybackConstraint)
+      })
+      it('failure - collection array does not have valid addresses', async () => {
+        await expect(
+          provider.contract.customBuyback(
+            BigInt(1000000000),
+            [{ account: '0xinvalid', bps: BigInt(0) }],
+            []
+          )
+        ).rejects.toThrow(commonErrorMessage.wrongAddressFormat)
+      })
+      it('failure - distribution array does not have valid addresses', async () => {
+        await expect(
+          provider.contract.customBuyback(
+            BigInt(1000000000),
+            [],
+            [{ account: '0xinvalid', bps: BigInt(0) }]
+          )
+        ).rejects.toThrow(commonErrorMessage.wrongAddressFormat)
+      })
+      it('failure - collection array have zero bps', async () => {
+        await expect(
+          provider.contract.customBuyback(
+            BigInt(1000000000),
+            [
+              { account: signerAddress, bps: BigInt(1) },
+              { account: signerAddress, bps: BigInt(1) },
+              { account: signerAddress, bps: BigInt(0) }
+            ],
+            []
+          )
+        ).rejects.toThrow(buybackErrorMessage.nonNegativeOrZeroBps)
+      })
+      it('failure - collection array have negative bps', async () => {
+        await expect(
+          provider.contract.customBuyback(
+            BigInt(1000000000),
+            [
+              { account: signerAddress, bps: BigInt(1) },
+              { account: signerAddress, bps: BigInt(1) },
+              { account: signerAddress, bps: BigInt(-1) }
+            ],
+            []
+          )
+        ).rejects.toThrow(buybackErrorMessage.nonNegativeOrZeroBps)
+      })
+      it('failure - collection array bps is not 100%', async () => {
+        await expect(
+          provider.contract.customBuyback(
+            BigInt(1000000000),
+            [
+              { account: signerAddress, bps: BigInt(8000) },
+              { account: signerAddress, bps: BigInt(1500) }
+            ],
+            []
+          )
+        ).rejects.toThrow(buybackErrorMessage.collectionBpsConstraint)
+      })
+    })
+    describe('customBuybackWithdraw()', () => {
+      it.skip('failure - already withdrawn', async () => {
+        await expect(
+          provider.contract.customBuybackWithdraw(BigInt(0))
+        ).rejects.toThrow(buybackErrorMessage.alreadyWithdrawn)
+      })
+    })
+  })
 
   describe('Views', () => {
     it('success - get pool 1 fee', async () => {
@@ -156,6 +253,206 @@ describe('SelfProvider - Buyback', () => {
       expect(typeof maxLiquiditySlippage).toBe('bigint')
       expect(maxLiquiditySlippage).toBeGreaterThanOrEqual(BigInt(0))
       expect(maxLiquiditySlippage).toBeLessThanOrEqual(BigInt(10000))
+    })
+    describe('getBuyback()', () => {
+      it('failure - the buyback id is negative', async () => {
+        await expect(provider.contract.getBuyback(BigInt(-1))).rejects.toThrow(
+          buybackErrorMessage.nonExistBuybackId(BigInt(-1))
+        )
+      })
+      it('failure - the buyback does not exists', async () => {
+        await expect(provider.contract.getBuyback(MAX_BIGINT)).rejects.toThrow(
+          buybackErrorMessage.nonExistBuybackId(MAX_BIGINT)
+        )
+      })
+      it('failure - the buyback does not exists due id max value', async () => {
+        await expect(
+          provider.contract.getBuyback(BigInt(1) << BigInt(512))
+        ).rejects.toThrow(
+          buybackErrorMessage.nonExistBuybackId(BigInt(1) << BigInt(512))
+        )
+      })
+    })
+    describe('getCustomBuyback()', () => {
+      it('failure - the buyback id is negative', async () => {
+        await expect(
+          provider.contract.getCustomBuyback(BigInt(-1))
+        ).rejects.toThrow(
+          buybackErrorMessage.nonExistCustomBuybackId(BigInt(-1))
+        )
+      })
+      it('failure - the buyback does not exists', async () => {
+        await expect(
+          provider.contract.getCustomBuyback(MAX_BIGINT)
+        ).rejects.toThrow(
+          buybackErrorMessage.nonExistCustomBuybackId(MAX_BIGINT)
+        )
+      })
+    })
+    describe('fetchActiveLocks()', () => {
+      it('failure - the index is negative', async () => {
+        await expect(
+          provider.contract.fetchActiveLocks(BigInt(-1))
+        ).rejects.toThrow(buybackErrorMessage.nonNegativeBuybackId)
+      })
+      it('failure - the buyback does not exists', async () => {
+        await expect(
+          provider.contract.fetchActiveLocks(MAX_BIGINT)
+        ).rejects.toThrow(buybackErrorMessage.nonExistBuybackId(MAX_BIGINT))
+      })
+    })
+    describe('fetchActiveCustomLocks()', () => {
+      it('failure - the index is negative', async () => {
+        await expect(
+          provider.contract.fetchActiveCustomLocks(BigInt(-1))
+        ).rejects.toThrow(buybackErrorMessage.nonNegativeBuybackId)
+      })
+      it('failure - the custom buyback does not exists', async () => {
+        await expect(
+          provider.contract.fetchActiveCustomLocks(MAX_BIGINT)
+        ).rejects.toThrow(
+          buybackErrorMessage.nonExistCustomBuybackId(MAX_BIGINT)
+        )
+      })
+    })
+    describe('calculateOptimalAmount()', () => {
+      it('failure - the pool1 is not a valid address', async () => {
+        await expect(
+          provider.contract.calculateOptimalAmount(
+            '0xInvalid',
+            signerAddress,
+            BigInt(1000)
+          )
+        ).rejects.toThrow(commonErrorMessage.wrongAddressFormat)
+      })
+      it('failure - the pool2 is not a valid address', async () => {
+        await expect(
+          provider.contract.calculateOptimalAmount(
+            signerAddress,
+            '0xInvalid',
+            BigInt(1000)
+          )
+        ).rejects.toThrow(commonErrorMessage.wrongAddressFormat)
+      })
+      it('failure - the usdcAmount is zero', async () => {
+        await expect(
+          provider.contract.calculateOptimalAmount(
+            signerAddress,
+            signerAddress,
+            BigInt(0)
+          )
+        ).rejects.toThrow(buybackErrorMessage.nonNegativeAmountOrZero)
+      })
+      it('failure - the usdcAmount is negative', async () => {
+        await expect(
+          provider.contract.calculateOptimalAmount(
+            signerAddress,
+            signerAddress,
+            BigInt(-1)
+          )
+        ).rejects.toThrow(buybackErrorMessage.nonNegativeAmountOrZero)
+      })
+    })
+    describe('estimateAmountOut()', () => {
+      it('failure - the tokenIn is not a valid address', async () => {
+        await expect(
+          provider.contract.estimateAmountOut(
+            '0xInvalid',
+            BigInt(0),
+            signerAddress,
+            BigInt(0),
+            signerAddress
+          )
+        ).rejects.toThrow(commonErrorMessage.wrongAddressFormat)
+      })
+      it('failure - the tokenOut is not a valid address', async () => {
+        await expect(
+          provider.contract.estimateAmountOut(
+            signerAddress,
+            BigInt(0),
+            '0xInvalid',
+            BigInt(0),
+            signerAddress
+          )
+        ).rejects.toThrow(commonErrorMessage.wrongAddressFormat)
+      })
+      it('failure - the pool is not a valid address', async () => {
+        await expect(
+          provider.contract.estimateAmountOut(
+            signerAddress,
+            BigInt(0),
+            signerAddress,
+            BigInt(0),
+            '0xInvalid'
+          )
+        ).rejects.toThrow(commonErrorMessage.wrongAddressFormat)
+      })
+      it('failure - the amountIn is zero', async () => {
+        await expect(
+          provider.contract.estimateAmountOut(
+            signerAddress,
+            BigInt(0),
+            signerAddress,
+            BigInt(0),
+            signerAddress
+          )
+        ).rejects.toThrow(buybackErrorMessage.nonNegativeAmountOrZero)
+      })
+      it('failure - the amountIn is negative', async () => {
+        await expect(
+          provider.contract.estimateAmountOut(
+            signerAddress,
+            BigInt(-1),
+            signerAddress,
+            BigInt(0),
+            signerAddress
+          )
+        ).rejects.toThrow(buybackErrorMessage.nonNegativeAmountOrZero)
+      })
+      it('failure - the amountIn its over 128 bits', async () => {
+        await expect(
+          provider.contract.estimateAmountOut(
+            signerAddress,
+            BigInt(2) ** BigInt(128),
+            signerAddress,
+            BigInt(0),
+            signerAddress
+          )
+        ).rejects.toThrow(
+          commonErrorMessage.nonGreaterThan('amountIn', '128 bits')
+        )
+      })
+      it('failure - the secondsAgo is negative', async () => {
+        await expect(
+          provider.contract.estimateAmountOut(
+            signerAddress,
+            BigInt(100),
+            signerAddress,
+            BigInt(-1),
+            signerAddress
+          )
+        ).rejects.toThrow(buybackErrorMessage.nonNegativeSecondsOrZero)
+      })
+      it('failure - the secondsAgo its over 32 bits', async () => {
+        await expect(
+          provider.contract.estimateAmountOut(
+            signerAddress,
+            BigInt(2) ** BigInt(32),
+            signerAddress,
+            BigInt(2) ** BigInt(32),
+            signerAddress
+          )
+        ).rejects.toThrow(
+          commonErrorMessage.nonGreaterThan('secondsAgo', '32 bits')
+        )
+      })
+    })
+    describe('recoverERC20()', () => {
+      it('failure - the tokenIn is not a valid address', async () => {
+        await expect(
+          provider.contract.recoverERC20('0xInvalid')
+        ).rejects.toThrow(commonErrorMessage.wrongAddressFormat)
+      })
     })
   })
 })

--- a/test/integration/self-provider-buyback.test.ts
+++ b/test/integration/self-provider-buyback.test.ts
@@ -109,5 +109,28 @@ describe('SelfProvider - Buyback', () => {
 
       expect(ethers.isAddress(address)).toBe(true)
     })
+    it('success - get recover', async () => {
+      const address = await provider.contract.getRecovererAddress()
+
+      expect(ethers.isAddress(address)).toBe(true)
+    })
+    it('success - get buy frequency', async () => {
+      expect.assertions(2)
+
+      const buyFrequency = await provider.contract.getBuyFrequency()
+
+      expect(typeof buyFrequency).toBe('bigint')
+      expect(buyFrequency).toBeGreaterThanOrEqual(BigInt(0))
+    })
+    it('success - get max liquidity slippage', async () => {
+      expect.assertions(3)
+
+      const maxLiquiditySlippage =
+        await provider.contract.getMaxLiquiditySlippage()
+
+      expect(typeof maxLiquiditySlippage).toBe('bigint')
+      expect(maxLiquiditySlippage).toBeGreaterThanOrEqual(BigInt(0))
+      expect(maxLiquiditySlippage).toBeLessThanOrEqual(BigInt(10000))
+    })
   })
 })

--- a/test/integration/self-provider-buyback.test.ts
+++ b/test/integration/self-provider-buyback.test.ts
@@ -458,10 +458,43 @@ describe('SelfProvider - Buyback', () => {
       })
     })
     describe('recoverERC20()', () => {
-      it('failure - the tokenIn is not a valid address', async () => {
+      it('failure - the token is not a valid address', async () => {
         await expect(
           provider.contract.recoverERC20('0xInvalid')
         ).rejects.toThrow(commonErrorMessage.wrongAddressFormat)
+      })
+      it('failure - the signer address is not the recoverer address', async () => {
+        const usdc = await provider.contract.getUSDC()
+
+        await expect(provider.contract.recoverERC20(usdc)).rejects.toThrow(
+          buybackErrorMessage.addressIsNotRecoverer
+        )
+      })
+      it('failure - the token is the usdc address', async () => {
+        const usdc = await provider.contract.getUSDC()
+        const providerWithoutPk = new SelfProvider(
+          Buyback,
+          BUYBACK_CONTRACT_ADDRESS,
+          provider.contract.apiUrl,
+          ''
+        )
+
+        await expect(
+          providerWithoutPk.contract.recoverERC20(usdc)
+        ).rejects.toThrow(commonErrorMessage.invalidToken)
+      })
+      it('failure - the token is the factr address', async () => {
+        const factr = await provider.contract.getFACTR()
+        const providerWithoutPk = new SelfProvider(
+          Buyback,
+          BUYBACK_CONTRACT_ADDRESS,
+          provider.contract.apiUrl,
+          ''
+        )
+
+        await expect(
+          providerWithoutPk.contract.recoverERC20(factr)
+        ).rejects.toThrow(commonErrorMessage.invalidToken)
       })
     })
   })

--- a/test/integration/self-provider-buyback.test.ts
+++ b/test/integration/self-provider-buyback.test.ts
@@ -1,6 +1,7 @@
 import { ethers } from 'ethers'
 import timekeeper from 'timekeeper'
 
+import { Erc20 } from '../../src'
 import { Buyback } from '../../src/buyback'
 import { SelfProvider } from '../../src/provider'
 import {
@@ -95,19 +96,43 @@ describe('SelfProvider - Buyback', () => {
       expect(ethers.isAddress(address)).toBe(true)
     })
     it('success - get factr', async () => {
+      expect.assertions(3)
+
       const address = await provider.contract.getFACTR()
 
       expect(ethers.isAddress(address)).toBe(true)
+
+      const erc20 = new Erc20(address, provider.contract.apiUrl, null)
+      const decimals = await erc20.decimals()
+
+      expect(typeof decimals).toBe('bigint')
+      expect(decimals).toBeGreaterThanOrEqual(BigInt(0))
     })
     it('success - get usdc', async () => {
+      expect.assertions(3)
+
       const address = await provider.contract.getUSDC()
 
       expect(ethers.isAddress(address)).toBe(true)
+
+      const erc20 = new Erc20(address, provider.contract.apiUrl, null)
+      const decimals = await erc20.decimals()
+
+      expect(typeof decimals).toBe('bigint')
+      expect(decimals).toBeGreaterThanOrEqual(BigInt(0))
     })
     it('success - get weth', async () => {
+      expect.assertions(3)
+
       const address = await provider.contract.getWETH()
 
       expect(ethers.isAddress(address)).toBe(true)
+
+      const erc20 = new Erc20(address, provider.contract.apiUrl, null)
+      const decimals = await erc20.decimals()
+
+      expect(typeof decimals).toBe('bigint')
+      expect(decimals).toBeGreaterThanOrEqual(BigInt(0))
     })
     it('success - get recover', async () => {
       const address = await provider.contract.getRecovererAddress()

--- a/test/test-util.ts
+++ b/test/test-util.ts
@@ -30,6 +30,8 @@ export const COLLATERAL_ERC20_TOKENS = [
 ]
 export const AMOY_STAKING_CONTRACT_ADDRESS =
   '0xF9539F81CFC87F80BafEBe68DD2ca681Be970Eaf'
+export const BUYBACK_CONTRACT_ADDRESS =
+  '0x615e1f7970363Fbf7A1843eFc16f0E4e685610F9'
 
 export const loadEnv = async (): Promise<void> => {
   const dotenv = await import('dotenv')


### PR DESCRIPTION
## Add support to `buyback` contract

## Description

### Summary

- Add `Buyback` class to support the buyback contract

### Changes

- Add `CoreContract` class to contracts without admin or pausable functionality
- Add the abi of the v2 of buyback contract
- Add functions to integrate with the buyback smart contract 
- Add the unit failure test cases to check the validations before call the contract action

## Related Issue

- Resolves #230

## How Has This Been Tested?

Add new test cases and check that all of them passed

<img width="278" alt="image" src="https://github.com/user-attachments/assets/e6292712-8482-4bb3-8112-a4d358ae2bc2">


