### PR TITLE
feat: support staking expiration plan

### DIFF
--- a/.changeset/clever-pots-behave.md
+++ b/.changeset/clever-pots-behave.md
@@ -1,0 +1,8 @@
+---
+"@defactor/defactor-sdk": patch
+---
+
+Add support to Staking contract version with expiring plans
+
+- Extend `Plan` type to include optional `expires` attribute
+- Add `StakingExpiration` to support the version with expiring plans

--- a/src/artifacts/StakingExpiration.json
+++ b/src/artifacts/StakingExpiration.json
@@ -1,0 +1,771 @@
+{
+  "_format": "hh-sol-artifact-1",
+  "contractName": "Staking",
+  "sourceName": "contracts/Staking/Staking.sol",
+  "abi": [
+    {
+      "inputs": [],
+      "name": "InvalidPlan",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidStakeIndex",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "PlanHasExpired",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "StakeAlreadyUnstaked",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "StakeAmountTooLow",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "StakeIsLocked",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "StakingCantBeLessThanRewardsEnd",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "StakingHasEnded",
+      "type": "error"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "planId",
+          "type": "uint8"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "stakeIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "Claimed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint48",
+          "name": "stakingEndTime",
+          "type": "uint48"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint48",
+          "name": "rewardsEndTime",
+          "type": "uint48"
+        }
+      ],
+      "name": "DatesUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "version",
+          "type": "uint8"
+        }
+      ],
+      "name": "Initialized",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Paused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "planId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint48",
+          "name": "lockDuration",
+          "type": "uint48"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint16",
+          "name": "apy",
+          "type": "uint16"
+        }
+      ],
+      "name": "PlanAdded",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "previousAdminRole",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "newAdminRole",
+          "type": "bytes32"
+        }
+      ],
+      "name": "RoleAdminChanged",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleGranted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "sender",
+          "type": "address"
+        }
+      ],
+      "name": "RoleRevoked",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "planId",
+          "type": "uint8"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "stakeIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "Staked",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "Unpaused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint8",
+          "name": "planId",
+          "type": "uint8"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "stakeIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "Unstaked",
+      "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "DEFAULT_ADMIN_ROLE",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "TOKEN",
+      "outputs": [
+        {
+          "internalType": "contract IERC20Upgradeable",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "_admin",
+          "type": "address"
+        },
+        {
+          "internalType": "contract IERC20Upgradeable",
+          "name": "_token",
+          "type": "address"
+        },
+        {
+          "internalType": "uint48",
+          "name": "_stakingEndTime",
+          "type": "uint48"
+        },
+        {
+          "internalType": "uint48",
+          "name": "_rewardsEndTime",
+          "type": "uint48"
+        }
+      ],
+      "name": "__Staking_init",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint48",
+          "name": "lockDuration",
+          "type": "uint48"
+        },
+        {
+          "internalType": "uint16",
+          "name": "apy",
+          "type": "uint16"
+        }
+      ],
+      "name": "addPlan",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        }
+      ],
+      "name": "balanceOf",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_stakeIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "claimRewards",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "getPlans",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint48",
+              "name": "lockDuration",
+              "type": "uint48"
+            },
+            {
+              "internalType": "uint48",
+              "name": "expires",
+              "type": "uint48"
+            },
+            {
+              "internalType": "uint16",
+              "name": "apy",
+              "type": "uint16"
+            }
+          ],
+          "internalType": "struct IStaking.Plan[]",
+          "name": "",
+          "type": "tuple[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        }
+      ],
+      "name": "getRoleAdmin",
+      "outputs": [
+        {
+          "internalType": "bytes32",
+          "name": "",
+          "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "user",
+          "type": "address"
+        }
+      ],
+      "name": "getUserStakes",
+      "outputs": [
+        {
+          "components": [
+            {
+              "internalType": "uint256",
+              "name": "amount",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint256",
+              "name": "claimed",
+              "type": "uint256"
+            },
+            {
+              "internalType": "uint48",
+              "name": "stakeTime",
+              "type": "uint48"
+            },
+            {
+              "internalType": "uint8",
+              "name": "planId",
+              "type": "uint8"
+            },
+            {
+              "internalType": "bool",
+              "name": "unstaked",
+              "type": "bool"
+            }
+          ],
+          "internalType": "struct IStaking.Stake[]",
+          "name": "",
+          "type": "tuple[]"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "grantRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "hasRole",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "pause",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "paused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "renounceRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint8",
+          "name": "_planId",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_stakeIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "restake",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes32",
+          "name": "role",
+          "type": "bytes32"
+        },
+        {
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "revokeRole",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "rewardsEndTime",
+      "outputs": [
+        {
+          "internalType": "uint48",
+          "name": "",
+          "type": "uint48"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint48",
+          "name": "_stakingEndTime",
+          "type": "uint48"
+        },
+        {
+          "internalType": "uint48",
+          "name": "_rewardsEndTime",
+          "type": "uint48"
+        }
+      ],
+      "name": "setDates",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "planId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint48",
+          "name": "planExpiration",
+          "type": "uint48"
+        }
+      ],
+      "name": "setPlanExpiration",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint8",
+          "name": "_planId",
+          "type": "uint8"
+        },
+        {
+          "internalType": "uint256",
+          "name": "_amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "stake",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "stakingEndTime",
+      "outputs": [
+        {
+          "internalType": "uint48",
+          "name": "",
+          "type": "uint48"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bytes4",
+          "name": "interfaceId",
+          "type": "bytes4"
+        }
+      ],
+      "name": "supportsInterface",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "totalFactrStaked",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "unpause",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_stakeIndex",
+          "type": "uint256"
+        }
+      ],
+      "name": "unstake",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "contract IERC20Upgradeable",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        }
+      ],
+      "name": "withdraw",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    }
+  ],
+  "linkReferences": {},
+  "deployedLinkReferences": {}
+}

--- a/src/artifacts/index.ts
+++ b/src/artifacts/index.ts
@@ -5,6 +5,7 @@ import miscErc20CollateralPool from './ERC20CollateralPool.json'
 import miscErc20CollateralPoolToplend from './ERC20CollateralPoolToplend.json'
 import miscPools from './Pools.json'
 import miscStaking from './Staking.json'
+import miscStakingExpiration from './StakingExpiration.json'
 
 export {
   miscErc20CollateralPool,
@@ -12,6 +13,7 @@ export {
   miscAdminPools,
   miscErc20,
   miscStaking,
+  miscStakingExpiration,
   miscErc20CollateralPoolToplend,
   miscBuyback
 }

--- a/src/errors/error-messages.ts
+++ b/src/errors/error-messages.ts
@@ -88,7 +88,9 @@ export const counterPartyPoolErrorMessage = {
 export const stakingErrorMessage = {
   nonNegativeLockDuration: 'Lock duration cannot be negative',
   nonNegativeApy: 'APY cannot be negative',
+  nonNegativePlanExpiration: 'Plan expiration cannot be negative',
   invalidPlanId: 'Invalid plan id',
+  planHasExpired: 'The plan has expired',
   stakeAmountTooLow: 'Stake amount too low',
   stakingHasEnded: 'Staking has ended',
   stakeAlreadyUnstaked: 'Stake already unstaked',

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,7 @@ import {
 } from './pools'
 import * as AssistedProvider from './provider/assisted.provider'
 import * as SelfProvider from './provider/self.provider'
-import { Staking } from './staking'
+import { Staking, StakingExpiration } from './staking'
 import { Erc20 } from './utilities/erc20'
 import * as generics from './utilities/generics'
 import * as util from './utilities/util'
@@ -33,6 +33,7 @@ export {
   Utilities,
   ERC20CollateralPool,
   Staking,
+  StakingExpiration,
   Erc20,
   Pools,
   AdminPools,

--- a/src/staking/index.ts
+++ b/src/staking/index.ts
@@ -1,1 +1,2 @@
 export * from './staking'
+export * from './staking-plan-expiration'

--- a/src/staking/staking-plan-expiration.ts
+++ b/src/staking/staking-plan-expiration.ts
@@ -1,0 +1,162 @@
+import { ContractTransaction, TransactionResponse } from 'ethers'
+
+import { stakingErrorMessage } from '../errors'
+import { ExpirationFunctions } from '../types/staking'
+import { Staking } from './staking'
+
+export class StakingExpiration extends Staking implements ExpirationFunctions {
+  async getBaseTokenAddress(): Promise<string> {
+    return await this.contract.TOKEN()
+  }
+
+  async addPlan(
+    lockDuration: bigint,
+    apy: bigint
+  ): Promise<ContractTransaction | TransactionResponse> {
+    await this._checkIsAdmin()
+
+    if (lockDuration < 0) {
+      throw new Error(stakingErrorMessage.nonNegativeLockDuration)
+    }
+
+    if (apy < 0) {
+      throw new Error(stakingErrorMessage.nonNegativeApy)
+    }
+
+    const pop = await this.contract.addPlan.populateTransaction(
+      lockDuration.toString(),
+      '0',
+      apy.toString()
+    )
+
+    return this.signer ? await this.signer.sendTransaction(pop) : pop
+  }
+
+  async setPlanExpiration(
+    planId: bigint,
+    planExpiration: bigint
+  ): Promise<ContractTransaction | TransactionResponse> {
+    await this._checkIsAdmin()
+
+    if (planId < 0) {
+      throw new Error(stakingErrorMessage.nonNegativeIndexId)
+    }
+
+    if (planExpiration < 0) {
+      throw new Error(stakingErrorMessage.nonNegativePlanExpiration)
+    }
+
+    const plans = await this.getPlans()
+
+    if (planId >= plans.length) {
+      throw new Error(stakingErrorMessage.invalidPlanId)
+    }
+
+    const pop = await this.contract.setPlanExpiration.populateTransaction(
+      planId,
+      planExpiration.toString()
+    )
+
+    return this.signer ? await this.signer.sendTransaction(pop) : pop
+  }
+
+  async stake(
+    planId: bigint,
+    amount: bigint
+  ): Promise<ContractTransaction | TransactionResponse> {
+    if (planId < 0) {
+      throw new Error(stakingErrorMessage.nonNegativeIndexId)
+    }
+
+    await this._checkIsNotPaused()
+
+    const plans = await this.getPlans()
+
+    if (planId >= plans.length) {
+      throw new Error(stakingErrorMessage.invalidPlanId)
+    }
+
+    if (amount < this.MIN_STAKE_AMOUNT) {
+      throw new Error(stakingErrorMessage.stakeAmountTooLow)
+    }
+
+    const currentTime = Math.floor(Date.now() / 1000)
+    const stakingEndTime = await this.stakingEndTime()
+
+    if (currentTime > stakingEndTime) {
+      throw new Error(stakingErrorMessage.stakingHasEnded)
+    }
+
+    const plan = plans[Number(planId)]
+
+    if (
+      typeof plan.expires === 'bigint' &&
+      plan.expires > 0 &&
+      plan.expires < currentTime
+    ) {
+      throw new Error(stakingErrorMessage.planHasExpired)
+    }
+
+    const pop = await this.contract.stake.populateTransaction(
+      planId,
+      amount.toString()
+    )
+
+    return this.signer ? await this.signer.sendTransaction(pop) : pop
+  }
+
+  async restake(
+    planId: bigint,
+    stakeIndex: bigint
+  ): Promise<ContractTransaction | TransactionResponse> {
+    if (planId < 0 || stakeIndex < 0) {
+      throw new Error(stakingErrorMessage.nonNegativeIndexId)
+    }
+
+    await this._checkIsNotPaused()
+
+    const plans = await this.getPlans()
+
+    if (planId >= plans.length) {
+      throw new Error(stakingErrorMessage.invalidPlanId)
+    }
+
+    const currentTime = Math.floor(Date.now() / 1000)
+    const stakingEndTime = await this.stakingEndTime()
+
+    if (currentTime > stakingEndTime) {
+      throw new Error(stakingErrorMessage.stakingHasEnded)
+    }
+
+    const plan = plans[Number(planId)]
+
+    if (
+      typeof plan.expires === 'bigint' &&
+      plan.expires > 0 &&
+      plan.expires < currentTime
+    ) {
+      throw new Error(stakingErrorMessage.planHasExpired)
+    }
+
+    if (this.signer) {
+      const userStake = await this.getUserStake(this.signer.address, stakeIndex)
+
+      if (userStake.unstaked) {
+        throw new Error(stakingErrorMessage.stakeAlreadyUnstaked)
+      }
+
+      const plan = plans[Number(userStake.planId)]
+
+      if (userStake.stakeTime + plan.lockDuration > currentTime) {
+        throw new Error(stakingErrorMessage.stakeIsLocked)
+      }
+    }
+
+    const pop = await this.contract.restake.populateTransaction(
+      planId,
+      stakeIndex
+    )
+
+    return this.signer ? await this.signer.sendTransaction(pop) : pop
+  }
+}

--- a/src/staking/staking-plan-expiration.ts
+++ b/src/staking/staking-plan-expiration.ts
@@ -20,29 +20,6 @@ export class StakingExpiration extends Staking implements ExpirationFunctions {
     return await this.contract.TOKEN()
   }
 
-  async addPlan(
-    lockDuration: bigint,
-    apy: bigint
-  ): Promise<ContractTransaction | TransactionResponse> {
-    await this._checkIsAdmin()
-
-    if (lockDuration < 0) {
-      throw new Error(stakingErrorMessage.nonNegativeLockDuration)
-    }
-
-    if (apy < 0) {
-      throw new Error(stakingErrorMessage.nonNegativeApy)
-    }
-
-    const pop = await this.contract.addPlan.populateTransaction(
-      lockDuration.toString(),
-      '0',
-      apy.toString()
-    )
-
-    return this.signer ? await this.signer.sendTransaction(pop) : pop
-  }
-
   async setPlanExpiration(
     planId: bigint,
     planExpiration: bigint

--- a/src/staking/staking-plan-expiration.ts
+++ b/src/staking/staking-plan-expiration.ts
@@ -1,10 +1,21 @@
 import { ContractTransaction, TransactionResponse } from 'ethers'
 
+import { miscStakingExpiration } from '../artifacts'
 import { stakingErrorMessage } from '../errors'
 import { ExpirationFunctions } from '../types/staking'
+import { Abi, PrivateKey } from '../types/types'
 import { Staking } from './staking'
 
 export class StakingExpiration extends Staking implements ExpirationFunctions {
+  constructor(
+    address: string,
+    apiUrl: string,
+    privateKey: PrivateKey | null,
+    abi?: Abi
+  ) {
+    super(address, apiUrl, privateKey, abi || miscStakingExpiration.abi)
+  }
+
   async getBaseTokenAddress(): Promise<string> {
     return await this.contract.TOKEN()
   }

--- a/src/types/staking.ts
+++ b/src/types/staking.ts
@@ -3,6 +3,7 @@ import { ethers } from 'ethers'
 export type Plan = {
   lockDuration: bigint
   apy: bigint
+  expires?: bigint
 }
 
 export type Stake = {
@@ -56,5 +57,12 @@ export interface Functions {
   ): Promise<ethers.ContractTransaction | ethers.TransactionResponse>
   claimRewards(
     stakeIndex: bigint
+  ): Promise<ethers.ContractTransaction | ethers.TransactionResponse>
+}
+
+export interface ExpirationFunctions {
+  setPlanExpiration(
+    planId: bigint,
+    planExpiration: bigint
   ): Promise<ethers.ContractTransaction | ethers.TransactionResponse>
 }

--- a/test/integration/self-provider-staking-expiration.test.ts
+++ b/test/integration/self-provider-staking-expiration.test.ts
@@ -1,0 +1,130 @@
+import { ethers } from 'ethers'
+import timekeeper from 'timekeeper'
+
+import { stakingErrorMessage } from '../../src/errors'
+import { SelfProvider } from '../../src/provider'
+import { StakingExpiration } from '../../src/staking'
+import { Plan } from '../../src/types/staking'
+import {
+  ADMIN_TESTING_PRIVATE_KEY,
+  AMOY_STAKING_CONTRACT_ADDRESS,
+  FACTR_TOKEN_ADDRESS,
+  MAX_BIGINT,
+  loadEnv
+} from '../test-util'
+
+jest.setTimeout(300000)
+
+describe('SelfProvider - Staking with plan Expiration', () => {
+  let provider: SelfProvider<StakingExpiration>
+  let signerAddress: string
+  let baseToken: string
+  const expirationTime = BigInt(1765052950)
+  const defaultPlans: ReadonlyArray<Plan> = [
+    {
+      lockDuration: BigInt(0),
+      expires: BigInt(0),
+      apy: BigInt(5)
+    },
+    {
+      lockDuration: BigInt(30 * 24 * 60 * 60),
+      expires: BigInt(0),
+      apy: BigInt(8)
+    },
+    {
+      lockDuration: BigInt(90 * 24 * 60 * 60),
+      expires: BigInt(0),
+      apy: BigInt(10)
+    },
+    {
+      lockDuration: BigInt(180 * 24 * 60 * 60),
+      expires: BigInt(0),
+      apy: BigInt(20)
+    },
+    {
+      lockDuration: BigInt(360 * 24 * 60 * 60),
+      expires: BigInt(0),
+      apy: BigInt(40)
+    }
+  ]
+
+  beforeAll(async () => {
+    await loadEnv()
+
+    if (!process.env.PROVIDER_URL) {
+      throw new Error('PROVIDER_URL is not defined')
+    }
+
+    baseToken = FACTR_TOKEN_ADDRESS
+    provider = new SelfProvider(
+      StakingExpiration,
+      AMOY_STAKING_CONTRACT_ADDRESS,
+      process.env.PROVIDER_URL,
+      ADMIN_TESTING_PRIVATE_KEY
+    )
+
+    signerAddress = provider.contract.signer?.address || ''
+
+    if (!signerAddress) {
+      throw new Error('signer address is not defined')
+    }
+  })
+
+  beforeEach(() => {
+    timekeeper.reset()
+  })
+
+  describe('Constant Variables', () => {
+    it('success - get base token address', async () => {
+      const baseTokenAddress = await provider.contract.getBaseTokenAddress()
+
+      expect(ethers.isAddress(baseTokenAddress)).toBe(true)
+      expect(baseTokenAddress).toBe(baseToken)
+    })
+  })
+
+  describe('Functions', () => {
+    describe('setPlanExpiration()', () => {
+      it('failure - Plan Id does not exist', async () => {
+        const planId = MAX_BIGINT
+        const expiration = BigInt(0)
+
+        await expect(
+          provider.contract.setPlanExpiration(planId, expiration)
+        ).rejects.toThrow(stakingErrorMessage.invalidPlanId)
+      })
+      it('failure - Expiration is negative', async () => {
+        const planId = BigInt(0)
+        const expiration = BigInt(-5)
+
+        await expect(
+          provider.contract.setPlanExpiration(planId, expiration)
+        ).rejects.toThrow(stakingErrorMessage.nonNegativePlanExpiration)
+      })
+      it('success - Set new Expiration time', async () => {
+        const planId = BigInt(0)
+        const expiration = expirationTime
+
+        await expect(
+          provider.contract.setPlanExpiration(planId, expiration)
+        ).resolves.not.toThrow()
+      })
+    })
+  })
+
+  describe('Views', () => {
+    describe('getPlans()', () => {
+      it('success - get plans', async () => {
+        const plans = await provider.contract.getPlans()
+
+        for (let i = 0; i < defaultPlans.length; i++) {
+          expect(plans[i].lockDuration).toBe(defaultPlans[i].lockDuration)
+          expect(plans[i].apy).toBe(defaultPlans[i].apy)
+          expect(plans[i].expires).toBe(
+            i > 0 ? defaultPlans[i].expires : expirationTime
+          )
+        }
+      })
+    })
+  })
+})

--- a/test/integration/self-provider-staking-expiration.test.ts
+++ b/test/integration/self-provider-staking-expiration.test.ts
@@ -10,6 +10,7 @@ import {
   AMOY_STAKING_CONTRACT_ADDRESS,
   FACTR_TOKEN_ADDRESS,
   MAX_BIGINT,
+  ONE_DAY_SEC,
   loadEnv
 } from '../test-util'
 
@@ -27,22 +28,22 @@ describe('SelfProvider - Staking with plan Expiration', () => {
       apy: BigInt(5)
     },
     {
-      lockDuration: BigInt(30 * 24 * 60 * 60),
+      lockDuration: BigInt(30 * ONE_DAY_SEC),
       expires: BigInt(0),
       apy: BigInt(8)
     },
     {
-      lockDuration: BigInt(90 * 24 * 60 * 60),
+      lockDuration: BigInt(90 * ONE_DAY_SEC),
       expires: BigInt(0),
       apy: BigInt(10)
     },
     {
-      lockDuration: BigInt(180 * 24 * 60 * 60),
+      lockDuration: BigInt(180 * ONE_DAY_SEC),
       expires: BigInt(0),
       apy: BigInt(20)
     },
     {
-      lockDuration: BigInt(360 * 24 * 60 * 60),
+      lockDuration: BigInt(360 * ONE_DAY_SEC),
       expires: BigInt(0),
       apy: BigInt(40)
     }

--- a/test/integration/self-provider-staking.test.ts
+++ b/test/integration/self-provider-staking.test.ts
@@ -11,6 +11,7 @@ import {
   ADMIN_TESTING_PRIVATE_KEY,
   AMOY_STAKING_CONTRACT_ADDRESS,
   FACTR_TOKEN_ADDRESS,
+  ONE_DAY_SEC,
   TESTING_PRIVATE_KEY,
   approveTokenAmount,
   loadEnv,
@@ -32,11 +33,11 @@ describe('SelfProvider - Staking', () => {
       apy: BigInt(5)
     },
     {
-      lockDuration: BigInt(90 * 24 * 60 * 60),
+      lockDuration: BigInt(90 * ONE_DAY_SEC),
       apy: BigInt(10)
     },
     {
-      lockDuration: BigInt(180 * 24 * 60 * 60),
+      lockDuration: BigInt(180 * ONE_DAY_SEC),
       apy: BigInt(25)
     }
   ]
@@ -365,7 +366,7 @@ describe('SelfProvider - Staking', () => {
     describe('addPlan()', () => {
       it('failure - not an admin', async () => {
         const res = notAdminProvider.contract.addPlan(
-          BigInt(180 * 24 * 60 * 60),
+          BigInt(180 * ONE_DAY_SEC),
           BigInt(25)
         )
 
@@ -388,7 +389,7 @@ describe('SelfProvider - Staking', () => {
 
       it('success - the plan is registered', async () => {
         const res = provider.contract.addPlan(
-          BigInt(180 * 24 * 60 * 60),
+          BigInt(180 * ONE_DAY_SEC),
           BigInt(25)
         )
 


### PR DESCRIPTION
## Support the staking contract version with expiring plans

## Description

### Summary

### Changes

- Extend the `Plan` type to include expiration time
- Add `StakingExpiration` class to support the expiring plans version

### Tests

![image](https://github.com/user-attachments/assets/4c1894ca-f840-4c8c-913f-98e78b2230a8)


## Related Issue

- Resolves #237